### PR TITLE
Set max width of to_screen to screen width

### DIFF
--- a/R/screen.R
+++ b/R/screen.R
@@ -41,7 +41,7 @@ to_screen  <- function (ht, ...) UseMethod('to_screen')
 to_screen.huxtable <- function (
         ht,
         min_width = ceiling(getOption('width') / 6),
-        max_width = Inf,
+        max_width = getOption('width', Inf),
         compact   = TRUE,
         colnames  = TRUE,
         color     = getOption('huxtable.color_screen', default = TRUE),

--- a/man/to_screen.Rd
+++ b/man/to_screen.Rd
@@ -11,7 +11,7 @@ print_screen(ht, ...)
 to_screen(ht, ...)
 
 \method{to_screen}{huxtable}(ht, min_width = ceiling(getOption("width")/6),
-  max_width = Inf, compact = TRUE, colnames = TRUE,
+  max_width = getOption("width", Inf), compact = TRUE, colnames = TRUE,
   color = getOption("huxtable.color_screen", default = TRUE), ...)
 }
 \arguments{
@@ -51,3 +51,4 @@ print_screen(ht)
 Other printing functions: \code{\link{print_html}},
   \code{\link{print_latex}}, \code{\link{print_md}}
 }
+\concept{printing functions}


### PR DESCRIPTION
Treat this as a proposal rather than a bug fix. I frequently include the following sentence as the caption in the output of my `huxreg` wrapper, `export_summs`: "All continuous predictors are mean-centered and scaled by 1 standard deviation."

I don't consider this particularly long but it, when combined with the note about the meaning of the asterisks, invariably makes the output difficult to read (in the console) because it makes the border lines overflow, thereby throwing off the alignment of everything. I don't want to manually put line breaks into the caption since that would make the formatting wrong when exporting to other formats. 

There could be other ways to change the behavior than what I've done here, but let me know what you think.