### PR TITLE
Protect against upcoming tibble output in broom

### DIFF
--- a/R/huxreg.R
+++ b/R/huxreg.R
@@ -189,7 +189,7 @@ huxreg <- function (
   # create list of summary statistics
   all_sumstats <- lapply(models, function(m) {
     bg <- try(broom::glance(m), silent = TRUE)
-    bg <- if (class(bg) == 'try-error') {
+    bg <- if (inherits(bg, 'try-error')) {
       warning('No `glance` method for model of class ', class(m)[1])
       NULL
     } else t(bg)


### PR DESCRIPTION
Found this in a `revdepcheck` for `broom 0.5.0`, which returns tibbles from all tidiers.