### PR TITLE
Convert format_numbers type checker into a generic numeral_formatter.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -158,16 +158,39 @@ do_collapse <- function(ht, prop_fun, default) {
 }
 
 
+# Format numeral generics
+numeral_formatter <- function(x, numeral) {
+  UseMethod("numeral_formatter")
+}
+
+
+numeral_formatter.default <- function(x, numeral) {
+  stop('Unrecognized type of numeral_formatter')
+}
+
+
+# If we are a function then return output from the function
+numeral_formatter.function <- function(x, numeral) {
+  return(x)
+}
+
+
+numeral_formatter.character <- function(x, numeral) {
+  return(function(numeral) sprintf(x, numeral))
+}
+
+
+numeral_formatter.numeric <- function(x, numeral) {
+  return(function(numeral) formatC(round(numeral, x), format = 'f', digits = x))
+}
+
+
 # find each numeric substring, and replace it:
 format_numbers <- function (string, num_fmt) {
   # ! is.function avoids a warning if num_fmt is a function:
   if (! is.function(num_fmt) && is.na(num_fmt)) return(string)
 
-  format_numeral <- if (is.function(num_fmt)) num_fmt else
-        if (is.character(num_fmt)) function (numeral) sprintf(num_fmt, numeral) else
-        if (is.numeric(num_fmt)) function (numeral) formatC(round(numeral, num_fmt), format = 'f',
-          digits = num_fmt) else
-        stop('Unrecognized type of number_format: should be function, character or integer. See ?number_format')
+  format_numeral <- numeral_formatter(num_fmt, string)
   # Breakdown:
   # -?                    optional minus sign
   # [0-9]*                followed by any number of digits

--- a/R/utils.R
+++ b/R/utils.R
@@ -159,28 +159,28 @@ do_collapse <- function(ht, prop_fun, default) {
 
 
 # Format numeral generics
-numeral_formatter <- function(x, numeral) {
+numeral_formatter <- function (x, numeral) {
   UseMethod("numeral_formatter")
 }
 
 
-numeral_formatter.default <- function(x, numeral) {
-  stop('Unrecognized type of numeral_formatter')
+numeral_formatter.default <- function (x, numeral) {
+  stop('Unrecognized number_format. Please use a number, string or function.')
 }
 
 
 # If we are a function then return output from the function
-numeral_formatter.function <- function(x, numeral) {
+numeral_formatter.function <- function (x, numeral) {
   return(x)
 }
 
 
-numeral_formatter.character <- function(x, numeral) {
+numeral_formatter.character <- function (x, numeral) {
   return(function(numeral) sprintf(x, numeral))
 }
 
 
-numeral_formatter.numeric <- function(x, numeral) {
+numeral_formatter.numeric <- function (x, numeral) {
   return(function(numeral) formatC(round(numeral, x), format = 'f', digits = x))
 }
 


### PR DESCRIPTION
This removes the multiple if statement dispatch within the function, and should help with vectorising some functions.

If we are being perfectionist, it should be possible to create a function factory to replace format_numbers with a set of generic functions which share the relevant bit of code and have individual components for the bit which needs to differ. However, more studying of Advanced R (Wickham et al) needed for this.