### PR TITLE
Convert to vectors before calling `case_when()`

### DIFF
--- a/R/mapping-functions.R
+++ b/R/mapping-functions.R
@@ -453,7 +453,7 @@ by_regex <- function(..., .grepl_args = list(), ignore_na = TRUE) {
 #'
 #' `by_colorspace()` can be used to set background, border or
 #' text colors, visually differentiating high or low values.
-#' 
+#'
 #' @param ... Colors
 #' @param range Numeric endpoints. If `NULL`, these are determined from the data.
 #' @param na_color Color to return for `NA` values. Can be `NA` itself.
@@ -579,9 +579,13 @@ by_cases <- function (..., ignore_na = TRUE) {
   case_fn <- function (ht, rows, cols, current) {
     res <- current
     myenv <- new.env()
-    assign(".",  as.matrix(ht[rows, cols]), envir = myenv)
+    selection <- as.matrix(ht[rows, cols])
+    dim <- dim(selection)
+    selection <- as.vector(selection)
+    assign(".", selection, envir = myenv)
     cases <- lapply(cases, stats::as.formula, env = myenv)
     vals <- dplyr::case_when(!!! cases)
+    vals <- array(vals, dim = dim)
     res[] <- vals
     res <- maybe_ignore_na(res, current, ignore_na)
     res


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

- `case_when()` now uses vctrs, which generally makes it more generic when working with different data types. In huxtable it looks like you had logical matrices on the LHS of the `case_when()`, but those really weren't intended to be allowed and are now an error. It looks like you can just convert to vector and then redim afterwards, so that's what I've done here.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package in ahead of time! Thanks!