### PR TITLE
adding check_install for quick_* files where necessary

### DIFF
--- a/R/quick-functions.R
+++ b/R/quick-functions.R
@@ -152,7 +152,7 @@ quick_docx <- function (..., file = confirm("huxtable-output.docx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  rlang::check_installed(c("officer", "flextable"), reason="officer and flextable packages needed to create docx files") 
+  rlang::check_installed(c("officer", "flextable"), reason="to create docx files") 
 
   my_doc <- officer::read_docx()
   for (ht in hts) {
@@ -175,7 +175,7 @@ quick_pptx <- function (..., file = confirm("huxtable-output.pptx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  rlang::check_installed(c("officer", "flextable"), reason="officer and flextable packages needed to create pptx files")
+  rlang::check_installed(c("officer", "flextable"), reason="to create pptx files")
 
 
   my_pptx <- officer::read_pptx()
@@ -199,7 +199,7 @@ quick_xlsx <- function (..., file = confirm("huxtable-output.xlsx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  rlang::check_installed(c("openxlsx"), reason="openxlsx package needed to create openxlsx files") 
+  rlang::check_installed(c("openxlsx"), reason="to create openxlsx files") 
 
 
   wb <- openxlsx::createWorkbook()

--- a/R/quick-functions.R
+++ b/R/quick-functions.R
@@ -152,7 +152,7 @@ quick_docx <- function (..., file = confirm("huxtable-output.docx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  rlang::check_installed(c("officer", "flextable"), reason="to create docx files") 
+  assert_package("read_docx", "officer")
 
   my_doc <- officer::read_docx()
   for (ht in hts) {
@@ -175,7 +175,7 @@ quick_pptx <- function (..., file = confirm("huxtable-output.pptx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  rlang::check_installed(c("officer", "flextable"), reason="to create pptx files")
+  assert_package("read_pptx", "officer")
 
 
   my_pptx <- officer::read_pptx()
@@ -199,8 +199,7 @@ quick_xlsx <- function (..., file = confirm("huxtable-output.xlsx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  rlang::check_installed(c("openxlsx"), reason="to create openxlsx files") 
-
+  assert_package("createWorkbook", "openxlsx")
 
   wb <- openxlsx::createWorkbook()
   ix <- 0

--- a/R/quick-functions.R
+++ b/R/quick-functions.R
@@ -152,7 +152,7 @@ quick_docx <- function (..., file = confirm("huxtable-output.docx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  check_installed(c("officer", "flextable"), reason="officer and flextable packages needed to create docx files"), 
+  check_installed(c("officer", "flextable"), reason="officer and flextable packages needed to create docx files") 
 
   my_doc <- officer::read_docx()
   for (ht in hts) {
@@ -175,7 +175,7 @@ quick_pptx <- function (..., file = confirm("huxtable-output.pptx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  check_installed(c("officer", "flextable"), reason="officer and flextable packages needed to create pptx files"), 
+  check_installed(c("officer", "flextable"), reason="officer and flextable packages needed to create pptx files")
 
 
   my_pptx <- officer::read_pptx()
@@ -200,7 +200,7 @@ quick_xlsx <- function (..., file = confirm("huxtable-output.xlsx"), borders = 0
   force(file)
   hts <- huxtableize(list(...), borders)
   
-  check_installed(c("openxlsx"), reason="openxlsx package needed to create openxlsx files"), 
+  check_installed(c("openxlsx"), reason="openxlsx package needed to create openxlsx files") 
 
 
   wb <- openxlsx::createWorkbook()

--- a/R/quick-functions.R
+++ b/R/quick-functions.R
@@ -152,7 +152,7 @@ quick_docx <- function (..., file = confirm("huxtable-output.docx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  check_installed(c("officer", "flextable"), reason="officer and flextable packages needed to create docx files") 
+  rlang::check_installed(c("officer", "flextable"), reason="officer and flextable packages needed to create docx files") 
 
   my_doc <- officer::read_docx()
   for (ht in hts) {
@@ -175,7 +175,7 @@ quick_pptx <- function (..., file = confirm("huxtable-output.pptx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  check_installed(c("officer", "flextable"), reason="officer and flextable packages needed to create pptx files")
+  rlang::check_installed(c("officer", "flextable"), reason="officer and flextable packages needed to create pptx files")
 
 
   my_pptx <- officer::read_pptx()
@@ -199,8 +199,7 @@ quick_xlsx <- function (..., file = confirm("huxtable-output.xlsx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  
-  check_installed(c("openxlsx"), reason="openxlsx package needed to create openxlsx files") 
+  rlang::check_installed(c("openxlsx"), reason="openxlsx package needed to create openxlsx files") 
 
 
   wb <- openxlsx::createWorkbook()

--- a/R/quick-functions.R
+++ b/R/quick-functions.R
@@ -23,6 +23,9 @@ NULL
 #' interactive sessions, the default file path is "huxtable-output.xxx" in the working directory;
 #' if this already exists, you will be asked to confirm manually before proceeding.
 #'
+#' To create docx and pptx files `flextable` and `officer` must be installed, while xlsx
+#' needs `openxlsx`.
+#'
 #' @examples
 #' \dontrun{
 #'   m <- matrix(1:4, 2, 2)
@@ -149,6 +152,7 @@ quick_docx <- function (..., file = confirm("huxtable-output.docx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
+  check_installed(c("officer", "flextable"), reason="officer and flextable packages needed to create docx files"), 
 
   my_doc <- officer::read_docx()
   for (ht in hts) {
@@ -171,6 +175,8 @@ quick_pptx <- function (..., file = confirm("huxtable-output.pptx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
+  check_installed(c("officer", "flextable"), reason="officer and flextable packages needed to create pptx files"), 
+
 
   my_pptx <- officer::read_pptx()
   for (ht in hts) {
@@ -193,6 +199,9 @@ quick_xlsx <- function (..., file = confirm("huxtable-output.xlsx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
+  
+  check_installed(c("openxlsx"), reason="openxlsx package needed to create openxlsx files"), 
+
 
   wb <- openxlsx::createWorkbook()
   ix <- 0

--- a/R/quick-functions.R
+++ b/R/quick-functions.R
@@ -152,7 +152,8 @@ quick_docx <- function (..., file = confirm("huxtable-output.docx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  assert_package("read_docx", "officer")
+  assert_package("quick_docx", "officer")
+  assert_package("quick_docx", "flextable")
 
   my_doc <- officer::read_docx()
   for (ht in hts) {
@@ -175,7 +176,8 @@ quick_pptx <- function (..., file = confirm("huxtable-output.pptx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  assert_package("read_pptx", "officer")
+  assert_package("quick_pptx", "officer")
+  assert_package("quick_pptx", "flextable") # needed for as_flextable() below
 
 
   my_pptx <- officer::read_pptx()
@@ -199,7 +201,7 @@ quick_xlsx <- function (..., file = confirm("huxtable-output.xlsx"), borders = 0
   assert_that(is.flag(open))
   force(file)
   hts <- huxtableize(list(...), borders)
-  assert_package("createWorkbook", "openxlsx")
+  assert_package("quick_xlsx", "openxlsx")
 
   wb <- openxlsx::createWorkbook()
   ix <- 0


### PR DESCRIPTION
I added some lines to check if the requisite packages are available for the `quick_*()` functions. I also indicated in the documentation what packages were needed. 

(I was showing students huxtable in a bootcamp and the error thrown about needing to install packages threw them, this might be unnecessary but thought it would be helpful).