### PR TITLE
Fix missing newline at the end of latex dependencies

### DIFF
--- a/R/latex-dependencies.R
+++ b/R/latex-dependencies.R
@@ -58,7 +58,7 @@ report_latex_dependencies <- function(quiet = FALSE, as_string = FALSE) {
     cat(paste0(report, collapse = ""))
     cat("% These are LaTeX packages. You can install them using your LaTex management software,\n")
     cat("% or by running `huxtable::install_latex_dependencies()` from within R.\n")
-    cat("% Other packages may be required if you use non-standard tabulars (e.g. tabulary).")
+    cat("% Other packages may be required if you use non-standard tabulars (e.g. tabulary).\n")
   }
 
   if (as_string) {


### PR DESCRIPTION
The missing newline interfered with `do_write_latex_file`, which includes the optional `geometry` package only when dimensions are specified. That package ended up as part of the comment on the last line of the reported dependencies and hence setting dimensions did not work.