### PR TITLE
Refactor tests to avoid optional dependencies

### DIFF
--- a/tests/testthat/echo-true-latex-test.Rmd
+++ b/tests/testthat/echo-true-latex-test.Rmd
@@ -8,11 +8,11 @@ output: pdf_document
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
 library(huxtable)
-library(dplyr)
 ```
 
 ```{r}
-hux(a = 1:5, b = 1:5) %>% 
-  set_background_color(1:2, 1, "red") %>% 
-  set_text_color(2:3, 1:2, "green")
+h <- hux(a = 1:5, b = 1:5)
+h <- set_background_color(h, 1:2, 1, "red")
+h <- set_text_color(h, 2:3, 1:2, "green")
+h
 ```

--- a/tests/testthat/table-tester-2.Rmd
+++ b/tests/testthat/table-tester-2.Rmd
@@ -546,13 +546,6 @@ ht
 ```
 
 
-# Huxreg 
-
-```{r}
-huxreg(lm(iris$Sepal.Length~iris$Sepal.Width))
-
-```
-
 # hux_logo
 
 ```{r}


### PR DESCRIPTION
## Summary
- simplify PDF test by removing `dplyr` dependency and pipe
- drop `huxreg` demo from table tester to avoid `broom` requirement

## Testing
- `Rscript -e "rmarkdown::render('tests/testthat/echo-true-latex-test.Rmd', output_file=NULL, quiet=TRUE)"`
- `Rscript -e "rmarkdown::render('tests/testthat/table-tester-2.Rmd', output_format='html_document', output_file=NULL, quiet=TRUE)"`


------
https://chatgpt.com/codex/tasks/task_e_68922de76ec88330807a6b51358b61ce