### PR TITLE
ci: run covr coverage in separate macOS workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -86,9 +86,3 @@ jobs:
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
-
-      - name: Test coverage
-        run: |
-          remotes::install_cran("covr")
-          covr::codecov()
-        shell: Rscript {0}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,57 @@
+on: [push, pull_request]
+
+name: test-coverage
+
+jobs:
+  test-coverage:
+    runs-on: macOS-latest
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-tinytex@v2
+
+      - run: tlmgr update --self
+        env:
+          CTAN_REPO: https://mirror.las.iastate.edu/tex-archive/systems/texlive/tlnet/
+
+      - run: tlmgr install adjustbox ulem wrapfig threeparttable fontspec
+        env:
+          CTAN_REPO: https://mirror.las.iastate.edu/tex-archive/systems/texlive/tlnet/
+
+      - run: tlmgr install placeins
+        env:
+          CTAN_REPO: https://mirror.las.iastate.edu/tex-archive/systems/texlive/tlnet/
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install dependencies
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("covr")
+        shell: Rscript {0}
+
+      - name: Test coverage
+        run: covr::codecov()
+        shell: Rscript {0}


### PR DESCRIPTION
## Summary
- stop running covr in the R-CMD-check matrix
- add dedicated test-coverage workflow on macOS-latest

## Testing
- `R -q -e 'devtools::load_all(); testthat::test_file("tests/testthat/test-attributes.R")'`


------
https://chatgpt.com/codex/tasks/task_e_6892deb0bad483308664b1affde1b8e1