### PR TITLE
Run code coverage only on macOS

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -88,6 +88,7 @@ jobs:
           path: check
 
       - name: Test coverage
+        if: matrix.config.os == 'macOS-latest'
         run: |
           remotes::install_cran("covr")
           covr::codecov()


### PR DESCRIPTION
## Summary
- run code coverage step only on macOS-latest

## Testing
- `Rscript -e 'devtools::load_all(); testthat::test_file("tests/testthat/test-attributes.R")'`

------
https://chatgpt.com/codex/tasks/task_e_68933fa8bda88330a712813853702bec