### PR TITLE
Refactor bold attribute helpers

### DIFF
--- a/R/properties-cell.R
+++ b/R/properties-cell.R
@@ -362,8 +362,55 @@ make_getter_setters("na_string", "cell", check_fun = is.character)
 #' @template getset-visible-rowspec-example
 #' @templateVar attr_val2 FALSE
 #' @family formatting functions
-NULL
-make_getter_setters("bold", "cell", default = TRUE, check_fun = is.logical)
+bold <- function (ht) {
+  attr(ht, "bold")
+}
+
+`bold<-` <- function (ht, value) {
+  if (! all(is.na(value))) stopifnot(is.logical(value))
+  value[is.na(value)] <- huxtable_env$huxtable_default_attrs$bold
+  attr(ht, "bold")[] <- value
+  mode(attr(ht, "bold")) <- mode(value)
+  ht
+}
+
+#' @rdname bold
+#' @usage NULL
+set_bold <- function (ht, row, col, value = TRUE) {
+  assert_that(is_huxtable(ht))
+  if (nargs() == 2) {
+    if (missing(value)) value <- row
+    row <- seq_len(nrow(ht))
+    col <- seq_len(ncol(ht))
+  }
+
+  rc <- list()
+  rc$row <- get_rc_spec(ht, row, 1)
+  rc$col <- get_rc_spec(ht, col, 2)
+  attr(ht, "bold")[rc$row, rc$col] <- value
+
+  ht
+}
+
+#' @rdname bold
+#' @usage NULL
+map_bold <- function (ht, row, col, fn) {
+  assert_that(is_huxtable(ht))
+  if (nargs() == 2) {
+    if (missing(fn)) fn <- row
+    row <- seq_len(nrow(ht))
+    col <- seq_len(ncol(ht))
+  }
+  rc <- list()
+  rc$row <- get_rc_spec(ht, row, 1)
+  rc$col <- get_rc_spec(ht, col, 2)
+
+  current <- attr(ht, "bold")[rc$row, rc$col, drop = FALSE]
+  if (is_huxtable(current)) current <- as.matrix(current)
+  attr(ht, "bold")[rc$row, rc$col] <- fn(ht, rc$row, rc$col, current)
+
+  ht
+}
 
 
 #' @name italic

--- a/man/bold.Rd
+++ b/man/bold.Rd
@@ -16,6 +16,8 @@ bold(ht) <- value
 set_bold(ht, row, col, value = TRUE)
 map_bold(ht, row, col, fn)
 
+bold(ht)
+
 italic(ht)
 italic(ht) <- value
 set_italic(ht, row, col, value = TRUE)
@@ -28,11 +30,11 @@ map_italic(ht, row, col, fn)
 
 \item{col}{An optional column specifier.}
 
-\item{fn}{A mapping function. See \link{mapping-functions} for details.}
-
 \item{value}{A logical vector or matrix.
 
 Set to \code{NA} to reset to the default, which is \code{FALSE}.}
+
+\item{fn}{A mapping function. See \link{mapping-functions} for details.}
 }
 \value{
 \code{bold()} returns the \code{bold} property.


### PR DESCRIPTION
## Summary
- Replace make_getter_setters for bold with explicit bold(), bold()<-, set_bold(), and map_bold() helpers
- Regenerate roxygen docs for bold/italic functions

## Testing
- `devtools::test(filter='set-interface')`
- `devtools::test(filter='subset-replace')`
- `devtools::test(filter='dplyr')`
- `devtools::test(filter='manipulation-helpers')`
- `devtools::test(filter='attributes')`
- `devtools::test(filter='print')`


------
https://chatgpt.com/codex/tasks/task_e_689342d68d8c83308a70bacc13edd659