### PR TITLE
Document internal add_row_cols helper

### DIFF
--- a/R/bind-insert-internal.R
+++ b/R/bind-insert-internal.R
@@ -1,3 +1,13 @@
+#' Insert rows or columns into a huxtable
+#'
+#' @param x A huxtable to modify
+#' @param y Rows or columns to insert, as a huxtable
+#' @param after Row/column number or name after which to insert
+#' @param dimno Dimension to bind: 1 for rows, 2 for columns
+#' @param copy_cell_props Copy cell properties from `x` to `y`?
+#'
+#' @return A huxtable with rows or columns inserted
+#' @noRd
 add_row_cols <- function(x, y, after, dimno, copy_cell_props) {
   dims <- dim(x)
   end_idx <- dims[dimno]


### PR DESCRIPTION
## Summary
- Document internal `add_row_cols` utility with roxygen comments

## Testing
- `devtools::document()` (warnings about missing S3 export tags)
- `devtools::test(filter = "^(?!.*fuzz)", perl = TRUE)` (fails: LaTeX missing, dplyr method mismatch)


------
https://chatgpt.com/codex/tasks/task_e_68945761445c8330946cc4baa5495bcc