### PR TITLE
ci: restrict R-CMD-check to master

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,9 @@
 # https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
 on:
   push:
-    branches: [master]        # only run on pushes to main
+    branches: [master]        # only run on pushes to master
   pull_request:
-    branches: [master]        # run for PRs targeting main
+    branches: [master]        # run for PRs targeting master
 
 name: R-CMD-check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,6 +1,10 @@
 # For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
 # https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]        # only run on pushes to main
+  pull_request:
+    branches: [master]        # run for PRs targeting main
 
 name: R-CMD-check
 


### PR DESCRIPTION
## Summary
- scope R-CMD-check to run only on `master` for pushes and pull requests

## Testing
- `Rscript -e "devtools::test(filter='attributes')"`


------
https://chatgpt.com/codex/tasks/task_e_689464c8ca9083308fa90add2ca38b0a