### PR TITLE
Refactor utility helpers into dedicated modules

### DIFF
--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -1,38 +1,11 @@
-#' @import assertthat
-NULL
-
-
-ncharw <- function(x, type = "width") {
-  if (requireNamespace("crayon", quietly = TRUE)) {
-    x <- crayon::strip_style(x)
-  }
-  # we use stringi throughout to keep the same concept of width
-  switch(type,
-    width = stringi::stri_width(x),
-    chars = stringi::stri_length(x),
-    stop("Unrecognized type in ncharw")
-  )
-}
-
-
 is_vectorish <- function(x) is.null(dim(x)) && !is.list(x)
 
-
 is_numeric_or_character <- function(x) is.numeric(x) || is.character(x)
-
 
 # pinched from rlang
 `%||%` <- function(x, y) {
   if (is.null(x)) y else x
 }
-
-
-blank_where <- function(text, cond) {
-  stopifnot(length(text) == length(cond))
-  text[cond] <- ""
-  text
-}
-
 
 nest_strings <- function(...) {
   l <- list(...)
@@ -46,88 +19,9 @@ nest_strings <- function(...) {
 }
 
 
-# pinched from HMS. Registers the method or sets a hook to register it on load of other package
-register_s3_method <- function(pkg, generic, class = "huxtable") {
-  assert_that(is.string(pkg), is.string(generic))
-  fun <- get(paste0(generic, ".", class), envir = parent.frame())
-
-  if (pkg %in% loadedNamespaces()) {
-    registerS3method(generic, class, fun, envir = asNamespace(pkg))
-  }
-  setHook(packageEvent(pkg, "onLoad"), function(...) {
-    registerS3method(generic, class, fun, envir = asNamespace(pkg))
-  })
-}
-
-
-assert_package <- function(fun, package, version = NULL) {
-  if (!requireNamespace(package, quietly = TRUE)) {
-    stop(glue::glue(
-      "`{fun}` requires the \"{package}\" package. To install, type:\n",
-      "install.packages(\"{package}\")"
-    ))
-  }
-  if (!is.null(version)) {
-    cur_ver <- utils::packageVersion(package)
-    if (cur_ver < version) {
-      stop(glue::glue(
-        "`{fun}` requires version {version} or higher of the \"{package}\" ",
-        "package. You have version {cur_ver} installed. To update the package,",
-        "type:\n",
-        "install.packages(\"{package}\")"
-      ))
-    }
-  }
-}
-
-
 format_color <- function(r_color, default = "white") {
   r_color[is.na(r_color)] <- default
   apply(grDevices::col2rgb(r_color), 2, paste0, collapse = ", ")
-}
-
-
-# returns two rows(+1),cols(+1) arrays of border thicknesses.
-get_visible_borders <- function(ht) {
-  dc <- display_cells(ht)
-
-  # a vertical border is hidden, if it is shadowed by a cell to its left
-  vert_borders <- attr(ht, "lr_borders")$thickness
-  left_shadowed <- dc[dc$display_col < dc$col, ]
-  left_shadowed <- as.matrix(left_shadowed[c("row", "col")])
-  vert_borders[left_shadowed] <- 0
-
-  # a horizontal border is hidden, if it is shadowed by a cell above it
-  horiz_borders <- attr(ht, "tb_borders")$thickness
-  top_shadowed <- dc[dc$display_row < dc$row, ]
-  top_shadowed <- as.matrix(top_shadowed[c("row", "col")])
-  horiz_borders[top_shadowed] <- 0
-
-  res <- list(vert = vert_borders, horiz = horiz_borders)
-  return(res)
-}
-
-
-# returns two rows(+1),cols(+1) arrays of border colors.
-collapsed_border_colors <- function(ht) {
-  list(
-    vert  = attr(ht, "lr_borders")$color,
-    horiz = attr(ht, "tb_borders")$color
-  )
-}
-
-
-# returns two rows(+1),cols(+1) arrays of border styles.
-collapsed_border_styles <- function(ht) {
-  list(
-    vert  = attr(ht, "lr_borders")$style,
-    horiz = attr(ht, "tb_borders")$style
-  )
-}
-
-
-str_rep <- function(x, times) {
-  mapply(function(s, t) paste0(rep(s, t), collapse = ""), x, times)
 }
 
 

--- a/R/border-utils.R
+++ b/R/border-utils.R
@@ -1,0 +1,43 @@
+#' Compute visible borders accounting for hidden spans
+#'
+#' @noRd
+get_visible_borders <- function(ht) {
+  dc <- display_cells(ht)
+
+  # a vertical border is hidden, if it is shadowed by a cell to its left
+  vert_borders <- attr(ht, "lr_borders")$thickness
+  left_shadowed <- dc[dc$display_col < dc$col, ]
+  left_shadowed <- as.matrix(left_shadowed[c("row", "col")])
+  vert_borders[left_shadowed] <- 0
+
+  # a horizontal border is hidden, if it is shadowed by a cell above it
+  horiz_borders <- attr(ht, "tb_borders")$thickness
+  top_shadowed <- dc[dc$display_row < dc$row, ]
+  top_shadowed <- as.matrix(top_shadowed[c("row", "col")])
+  horiz_borders[top_shadowed] <- 0
+
+  res <- list(vert = vert_borders, horiz = horiz_borders)
+  return(res)
+}
+
+
+#' Collapsed border colors for vertical and horizontal borders
+#'
+#' @noRd
+collapsed_border_colors <- function(ht) {
+  list(
+    vert  = attr(ht, "lr_borders")$color,
+    horiz = attr(ht, "tb_borders")$color
+  )
+}
+
+
+#' Collapsed border styles for vertical and horizontal borders
+#'
+#' @noRd
+collapsed_border_styles <- function(ht) {
+  list(
+    vert  = attr(ht, "lr_borders")$style,
+    horiz = attr(ht, "tb_borders")$style
+  )
+}

--- a/R/package-utils.R
+++ b/R/package-utils.R
@@ -1,0 +1,41 @@
+#' @import assertthat
+NULL
+
+#' Register an S3 method on package load
+#'
+#' @noRd
+register_s3_method <- function(pkg, generic, class = "huxtable") {
+  assert_that(is.string(pkg), is.string(generic))
+  fun <- get(paste0(generic, ".", class), envir = parent.frame())
+
+  if (pkg %in% loadedNamespaces()) {
+    registerS3method(generic, class, fun, envir = asNamespace(pkg))
+  }
+  setHook(packageEvent(pkg, "onLoad"), function(...) {
+    registerS3method(generic, class, fun, envir = asNamespace(pkg))
+  })
+}
+
+
+#' Assert presence of suggested package and optional version
+#'
+#' @noRd
+assert_package <- function(fun, package, version = NULL) {
+  if (!requireNamespace(package, quietly = TRUE)) {
+    stop(glue::glue(
+      "`{fun}` requires the \"{package}\" package. To install, type:\n",
+      "install.packages(\"{package}\")"
+    ))
+  }
+  if (!is.null(version)) {
+    cur_ver <- utils::packageVersion(package)
+    if (cur_ver < version) {
+      stop(glue::glue(
+        "`{fun}` requires version {version} or higher of the \"{package}\" ",
+        "package. You have version {cur_ver} installed. To update the package,",
+        "type:\n",
+        "install.packages(\"{package}\")"
+      ))
+    }
+  }
+}

--- a/R/string-utils.R
+++ b/R/string-utils.R
@@ -1,0 +1,34 @@
+#' Count characters or width of strings
+#'
+#' Uses stringi to ensure consistent character width calculations.
+#'
+#' @noRd
+ncharw <- function(x, type = "width") {
+  if (requireNamespace("crayon", quietly = TRUE)) {
+    x <- crayon::strip_style(x)
+  }
+  # we use stringi throughout to keep the same concept of width
+  switch(type,
+    width = stringi::stri_width(x),
+    chars = stringi::stri_length(x),
+    stop("Unrecognized type in ncharw")
+  )
+}
+
+
+#' Replace elements with blanks where a condition is TRUE
+#'
+#' @noRd
+blank_where <- function(text, cond) {
+  stopifnot(length(text) == length(cond))
+  text[cond] <- ""
+  text
+}
+
+
+#' Repeat strings elementwise
+#'
+#' @noRd
+str_rep <- function(x, times) {
+  mapply(function(s, t) paste0(rep(s, t), collapse = ""), x, times)
+}


### PR DESCRIPTION
## Summary
- organize internal helpers into string, package, and border utility files
- keep existing API unchanged

## Testing
- `devtools::test(filter = 'new-borders|miscellaneous', perl = TRUE)`

------
https://chatgpt.com/codex/tasks/task_e_6894574a11ec8330859c18b8ce0d9e35