### PR TITLE
feat: translate padding to typst inset

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
   AFAIK nobody has ever done this; if I'm wrong, please tell me.
 * Reworked internals, with the halp of OpenAI Codex.
 
+## Other changes
+
+* Translate padding to Typst inset in typst_cell_options.
+
 # huxtable 5.6.0
 
 ## Breaking changes

--- a/R/typst.R
+++ b/R/typst.R
@@ -1,0 +1,34 @@
+#' Build Typst cell options
+#'
+#' Retrieve cell padding and translate to Typst inset arguments.
+#'
+#' @param ht A huxtable.
+#' @return A character matrix of Typst cell options.
+#' @noRd
+#'
+typst_cell_options <- function(ht) {
+  left <- left_padding(ht)
+  right <- right_padding(ht)
+  top <- top_padding(ht)
+  bottom <- bottom_padding(ht)
+  nrows <- nrow(ht)
+  ncols <- ncol(ht)
+  opts <- matrix("", nrow = nrows, ncol = ncols)
+  for (r in seq_len(nrows)) {
+    for (c in seq_len(ncols)) {
+      pads <- c(
+        top = top[r, c], right = right[r, c],
+        bottom = bottom[r, c], left = left[r, c]
+      )
+      pads <- pads[!is.na(pads)]
+      if (!length(pads)) next
+      if (length(pads) == 4 && length(unique(pads)) == 1) {
+        opts[r, c] <- sprintf("inset: %spt", pads[1])
+      } else {
+        parts <- paste0(names(pads), ": ", pads, "pt")
+        opts[r, c] <- paste0("inset: (", paste(parts, collapse = ", "), ")")
+      }
+    }
+  }
+  opts
+}

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -15,6 +15,12 @@ object. AFAIK nobody has ever done this; if I’m wrong, please tell me.
 \item Reworked internals, with the halp of OpenAI Codex.
 }
 }
+
+\subsection{Other changes}{
+\itemize{
+\item Translate padding to Typst inset in typst_cell_options.
+}
+}
 }
 
 \section{huxtable 5.6.0}{

--- a/tests/testthat/test-typst-cell-options.R
+++ b/tests/testthat/test-typst-cell-options.R
@@ -1,0 +1,16 @@
+local_edition(2)
+
+# Tests for typst_cell_options
+
+test_that("padding translates to typst inset", {
+  ht <- hux(a = 1)
+  ht <- set_left_padding(ht, 1)
+  ht <- set_right_padding(ht, 2)
+  ht <- set_top_padding(ht, 3)
+  ht <- set_bottom_padding(ht, 4)
+  opts <- huxtable:::typst_cell_options(ht)
+  expect_identical(
+    opts[1, 1],
+    "inset: (top: 3pt, right: 2pt, bottom: 4pt, left: 1pt)"
+  )
+})


### PR DESCRIPTION
## Summary
- support padding in Typst cell options via inset argument
- test asymmetric padding round-trip
- document change in NEWS

## Testing
- `devtools::test(filter = "typst-cell-options")`


------
https://chatgpt.com/codex/tasks/task_e_6894a7c0352c8330b6f80cf8e79341a0