### PR TITLE
Style R/themes.R and remove unparsable example

### DIFF
--- a/R/themes.R
+++ b/R/themes.R
@@ -1,29 +1,23 @@
-
-theme_maker <- function (
-        col1,
-        col2,
-        border_color = "white",
-        header_color = col1,
-        header_text = NA
-      ) {
-
-  theme_fn <- function (
-          ht,
-          header_rows = TRUE,
-          header_cols = TRUE
-        ) {
+theme_maker <- function(col1,
+                        col2,
+                        border_color = "white",
+                        header_color = col1,
+                        header_text = NA) {
+  theme_fn <- function(ht,
+                       header_rows = TRUE,
+                       header_cols = TRUE) {
     ht <- set_all_borders(ht, 1)
     ht <- set_all_border_colors(ht, border_color)
     ht <- map_background_color(ht, by_rows(col1, col2))
     if (header_rows) {
-      bold(ht)[header_rows(ht), ]             <- TRUE
+      bold(ht)[header_rows(ht), ] <- TRUE
       background_color(ht)[header_rows(ht), ] <- header_color
-      text_color(ht)[header_rows(ht), ]       <- header_text
+      text_color(ht)[header_rows(ht), ] <- header_text
     }
     if (header_cols) {
-      bold(ht)[, header_cols(ht)]             <- TRUE
+      bold(ht)[, header_cols(ht)] <- TRUE
       background_color(ht)[, header_cols(ht)] <- header_color
-      text_color(ht)[, header_cols(ht)]       <- header_text
+      text_color(ht)[, header_cols(ht)] <- header_text
     }
     ht <- clean_outer_padding(ht, 6)
 
@@ -81,21 +75,6 @@ theme_maker <- function (
 #' theme_orange(jams)
 #' theme_green(jams)
 #' theme_mondrian(jams)
-#' \dontrun{
-#'   quick_pdf(
-#'           theme_plain(jams),
-#'           theme_basic(jams),
-#'           theme_compact(jams)
-#'           theme_striped(jams),
-#'           theme_article(jams),
-#'           theme_bright(jams),
-#'           theme_grey(jams),
-#'           theme_blue(jams),
-#'           theme_orange(jams),
-#'           theme_green(jams),
-#'           theme_mondrian(jams)
-#'         )
-#' }
 #'
 NULL
 
@@ -103,11 +82,9 @@ NULL
 #' @export
 #' @rdname themes
 #' @param position "left", "center" or "right"
-theme_plain <- function(
-        ht,
-        header_rows = TRUE,
-        position = "center"
-      ){
+theme_plain <- function(ht,
+                        header_rows = TRUE,
+                        position = "center") {
   ht <- set_outer_borders(ht)
   ht <- set_background_color(ht, evens, everywhere, "#F2F2F2")
   if (header_rows) {
@@ -123,27 +100,31 @@ theme_plain <- function(
 #' @export
 #' @rdname themes
 #' @param colors Colors for header rows. Can also be a palette function.
-theme_bright <- function (
-        ht,
-        header_rows = TRUE,
-        header_cols = FALSE,
-        colors = c("#7eabf2", "#e376e3", "#fcbb03", "#7aba59", "#fc0356"))
-      {
-  assert_that(is_hux(ht), is.flag(header_rows), is.flag(header_cols),
-      is.character(colors) || is.function(colors))
+theme_bright <- function(ht,
+                         header_rows = TRUE,
+                         header_cols = FALSE,
+                         colors = c("#7eabf2", "#e376e3", "#fcbb03", "#7aba59", "#fc0356")) {
+  assert_that(
+    is_hux(ht), is.flag(header_rows), is.flag(header_cols),
+    is.character(colors) || is.function(colors)
+  )
 
   if (is.function(colors)) colors <- colors(ncol(ht))
   ht <- set_all_borders(ht, 3)
-  ht <-  set_all_border_colors(ht, "white")
+  ht <- set_all_border_colors(ht, "white")
   if (header_rows) {
-    ht <-  map_background_color(ht, header_rows(ht),
-          everywhere, by_cols(colors))
-    ht <-  set_text_color(ht, header_rows(ht), everywhere, "white")
+    ht <- map_background_color(
+      ht, header_rows(ht),
+      everywhere, by_cols(colors)
+    )
+    ht <- set_text_color(ht, header_rows(ht), everywhere, "white")
   }
   if (header_cols) {
-    ht <-  map_background_color(ht, everywhere, header_cols(ht),
-          by_rows(colors))
-    ht <-  set_text_color(ht, everywhere, header_cols(ht), "white")
+    ht <- map_background_color(
+      ht, everywhere, header_cols(ht),
+      by_rows(colors)
+    )
+    ht <- set_text_color(ht, everywhere, header_cols(ht), "white")
   }
 
   ht
@@ -152,11 +133,9 @@ theme_bright <- function (
 
 #' @export
 #' @rdname themes
-theme_basic <- function (
-        ht,
-        header_rows = TRUE,
-        header_cols = FALSE
-      ) {
+theme_basic <- function(ht,
+                        header_rows = TRUE,
+                        header_cols = FALSE) {
   assert_that(is.flag(header_rows), is.flag(header_cols))
 
   ht <- set_all_borders(ht, 0)
@@ -177,11 +156,9 @@ theme_basic <- function (
 
 #' @export
 #' @rdname themes
-theme_compact <- function (
-        ht,
-        header_rows = TRUE,
-        header_cols = FALSE
-      ) {
+theme_compact <- function(ht,
+                          header_rows = TRUE,
+                          header_cols = FALSE) {
   assert_that(is.flag(header_rows), is.flag(header_cols))
 
   ht <- set_all_borders(ht, 0)
@@ -203,13 +180,11 @@ theme_compact <- function (
 #' @rdname themes
 #' @param stripe  Background colour for odd rows
 #' @param stripe2 Background colour for even rows
-theme_striped <- function (
-        ht,
-        stripe = "grey90",
-        stripe2 = "grey95",
-        header_rows = TRUE,
-        header_cols = TRUE
-      ) {
+theme_striped <- function(ht,
+                          stripe = "grey90",
+                          stripe2 = "grey95",
+                          header_rows = TRUE,
+                          header_cols = TRUE) {
   assert_that(is.flag(header_rows), is.flag(header_cols))
 
   ht <- set_all_borders(ht)
@@ -221,9 +196,9 @@ theme_striped <- function (
   }
   if (header_cols) {
     ht <- style_header_cols(ht,
-            bold = TRUE,
-            background_color = stripe
-          )
+      bold = TRUE,
+      background_color = stripe
+    )
   }
 
   ht
@@ -233,48 +208,46 @@ theme_striped <- function (
 #' @export
 #' @rdname themes
 theme_grey <- theme_maker(
-        col1         = grDevices::grey(.9),
-        col2         = grDevices::grey(.95),
-        header_color = grDevices::grey(.8)
-      )
+  col1         = grDevices::grey(.9),
+  col2         = grDevices::grey(.95),
+  header_color = grDevices::grey(.8)
+)
 
 
 #' @export
 #' @rdname themes
 theme_blue <- theme_maker(
-        col1         = "#A9CCE3",
-        col2         = "#D4E6F1",
-        header_color = "#5499C7",
-        header_text  = "white"
-      )
+  col1         = "#A9CCE3",
+  col2         = "#D4E6F1",
+  header_color = "#5499C7",
+  header_text  = "white"
+)
 
 
 #' @export
 #' @rdname themes
 theme_orange <- theme_maker(
-        col1         = "#F5CBA7",
-        col2         = "#FAE5D3",
-        header_color = "#D0D3D4"
-      )
+  col1         = "#F5CBA7",
+  col2         = "#FAE5D3",
+  header_color = "#D0D3D4"
+)
 
 
 #' @export
 #' @rdname themes
 theme_green <- theme_maker(
-        col1         = "#C8E6C9",
-        col2         = "#A5D6A7",
-        header_color = "#4CAF50",
-        header_text  = "white"
-      )
+  col1         = "#C8E6C9",
+  col2         = "#A5D6A7",
+  header_color = "#4CAF50",
+  header_text  = "white"
+)
 
 
 #' @export
 #' @rdname themes
-theme_article <- function (
-        ht,
-        header_rows = TRUE,
-        header_cols = TRUE
-      ) {
+theme_article <- function(ht,
+                          header_rows = TRUE,
+                          header_cols = TRUE) {
   assert_that(is.flag(header_rows), is.flag(header_cols))
 
   ht <- set_all_borders(ht, 0)
@@ -299,11 +272,9 @@ theme_article <- function (
 #' @param prop_colored Roughly what proportion of cells should have
 #'   a primary-color background?
 #' @param font Font to use. For LaTeX, try `"cmss"`.
-theme_mondrian <- function (
-        ht,
-        prop_colored = 0.1,
-        font = NULL
-      ) {
+theme_mondrian <- function(ht,
+                           prop_colored = 0.1,
+                           font = NULL) {
   assert_that(is.number(prop_colored), prop_colored >= 0, prop_colored <= 1)
 
   ht <- set_all_borders(ht, 2)
@@ -313,13 +284,13 @@ theme_mondrian <- function (
   colored <- sample.int(ncells, size = ceiling(ncells * prop_colored), replace = FALSE)
   colors <- sample(c("red", "blue", "yellow"), length(colored), replace = TRUE)
   background_color(ht)[colored] <- colors
-  if (! is.null(font)) font(ht) <- font
+  if (!is.null(font)) font(ht) <- font
 
   ht
 }
 
 
-clean_outer_padding <- function (ht, pad) {
+clean_outer_padding <- function(ht, pad) {
   # a tight pad works best for blank themes with dark borders;
   # for coloured backgrounds you don't want that
   ht <- set_left_padding(ht, everywhere, 1, pad)
@@ -331,5 +302,5 @@ clean_outer_padding <- function (ht, pad) {
 
 largest <- function(x) {
   xs <- c(x[-1], FALSE)
-  which(x & ! xs)
+  which(x & !xs)
 }

--- a/scripts/style.R
+++ b/scripts/style.R
@@ -4,4 +4,4 @@ if (!requireNamespace("styler", quietly = TRUE)) {
   stop("styler package is required. Install it via install.packages('styler')")
 }
 
-styler::style_pkg()
+styler::style_pkg(exclude_dirs = c("vignettes", "scripts"))

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -4,4 +4,3 @@ library(huxtable)
 
 we_are_in_R_CMD_check <- TRUE
 test_check("huxtable")
-

--- a/tests/testthat/quarto-test-tex-labels.qmd
+++ b/tests/testthat/quarto-test-tex-labels.qmd
@@ -10,5 +10,4 @@ Reference to \ref{blah-hux}
 library(huxtable)
 label(jams) <- "blah-hux"
 jams
-
 ```

--- a/tests/testthat/setup-functions.R
+++ b/tests/testthat/setup-functions.R
@@ -1,17 +1,18 @@
-
-skip_without_pandoc <- function () {
-  if (! rmarkdown::pandoc_available("1.12.3")) skip("Not testing, pandoc >= 1.12.3 is not available")
+skip_without_pandoc <- function() {
+  if (!rmarkdown::pandoc_available("1.12.3")) skip("Not testing, pandoc >= 1.12.3 is not available")
 }
 
 
-skip_on_R_CMD_check <- function () {
+skip_on_R_CMD_check <- function() {
   skip_if(exists("we_are_in_R_CMD_check"), "Not testing, code doesn't play well with R CMD check")
   skip_if(Sys.getenv("COVERAGE") != "", "Not testing, code doesn't play well with R CMD check")
 }
 
 
-require_temp_artefacts_dir <- function () {
-  if (dir.exists("temp-artefacts")) return(TRUE)
+require_temp_artefacts_dir <- function() {
+  if (dir.exists("temp-artefacts")) {
+    return(TRUE)
+  }
   if (dir.create("temp-artefacts", showWarnings = FALSE)) {
     return(TRUE)
   } else {

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -1,4 +1,3 @@
-
 ht <- huxtable(a = 1:5, b = letters[1:5], d = 1:5)
 
 

--- a/tests/testthat/test-column-to-header.R
+++ b/tests/testthat/test-column-to-header.R
@@ -1,4 +1,3 @@
-
 local_edition(2)
 
 test_that("column_to_header works", {
@@ -22,7 +21,7 @@ test_that("column_to_header arguments work", {
   expect_silent(jams5 <- column_to_header(jams, 1, ignore_headers = FALSE))
   expect_equivalent(contents(jams5)[1, 1], "Type")
 
-  iris_hux <- as_hux(iris, add_colnames = FALSE)[c(1:3, 51:53, 101:103),]
+  iris_hux <- as_hux(iris, add_colnames = FALSE)[c(1:3, 51:53, 101:103), ]
   expect_silent(iris_hux <- column_to_header(iris_hux, "Species", start_col = 3))
   expect_equivalent(contents(iris_hux)[1, 3], "setosa")
   expect_equivalent(colspan(iris_hux)[1, 3], 2)

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 skip_if_not_installed("dplyr")
@@ -15,9 +13,9 @@ test_that("select, rename and relocate", {
   expect_equivalent(bold(ht3), bold(ht))
 
   if (packageVersion("dplyr") > "0.8.5") {
-    ht4 <- dplyr::relocate(ht, b , a, .after = d)
+    ht4 <- dplyr::relocate(ht, b, a, .after = d)
     expect_identical(ht4, ht[c("c", "d", "b", "a")])
-    ht5 <- dplyr::relocate(ht, b , a, .before = d)
+    ht5 <- dplyr::relocate(ht, b, a, .before = d)
     expect_identical(ht5, ht[c("c", "b", "a", "d")])
   }
 })

--- a/tests/testthat/test-flextable.R
+++ b/tests/testthat/test-flextable.R
@@ -1,5 +1,3 @@
-
-
 skip_if_not_installed("flextable")
 
 test_that("Simple conversion works", {
@@ -23,10 +21,10 @@ test_that("Text properties work", {
 
 test_that("Borders work", {
   hx <- huxtable(a = 1:3, b = 4:6)
-  top_border(hx)[1, ]    <- 1
+  top_border(hx)[1, ] <- 1
   bottom_border(hx)[1, ] <- 2
-  left_border(hx)[, 1]   <- 1
-  right_border(hx)[, 2]  <- 1
+  left_border(hx)[, 1] <- 1
+  right_border(hx)[, 2] <- 1
   expect_error(as_flextable(hx), regexp = NA)
 })
 

--- a/tests/testthat/test-huxreg.R
+++ b/tests/testthat/test-huxreg.R
@@ -1,4 +1,3 @@
-
 local_edition(2)
 
 if (!requireNamespace("broom", quietly = TRUE)) {
@@ -36,8 +35,10 @@ test_that("huxreg confidence intervals work", {
   glm1 <- glm(I(y > 0) ~ a, dfr, family = binomial)
   library(nnet)
   mn <- nnet::multinom(I(y > 0) ~ a, dfr, trace = FALSE)
-  expect_silent(huxreg(lm1, lm2, glm1, mn, error_format = "{conf.low}-{conf.high}",
-        statistics = c("r.squared"), ci_level = 0.95))
+  expect_silent(huxreg(lm1, lm2, glm1, mn,
+    error_format = "{conf.low}-{conf.high}",
+    statistics = c("r.squared"), ci_level = 0.95
+  ))
 })
 
 test_that("huxreg confidence intervals work when tidy c.i.s not available", {
@@ -47,13 +48,14 @@ test_that("huxreg confidence intervals work when tidy c.i.s not available", {
   set.seed(27101975)
   data(Orthodont, package = "nlme")
   # method ML avoids a warning in broom::glance
-  fm1 <- nlme::lme(distance ~ age + Sex, data = Orthodont, random = ~ 1, method = "ML")
+  fm1 <- nlme::lme(distance ~ age + Sex, data = Orthodont, random = ~1, method = "ML")
   expect_error(
-          huxreg(fm1, tidy_args = list(effects = "fixed"), statistics = "nobs", ci_level = 0.95,
-                error_format = "({conf.low}-{conf.high})"),
-          regexp = NA
-        )
-
+    huxreg(fm1,
+      tidy_args = list(effects = "fixed"), statistics = "nobs", ci_level = 0.95,
+      error_format = "({conf.low}-{conf.high})"
+    ),
+    regexp = NA
+  )
 })
 
 
@@ -120,15 +122,23 @@ test_that("huxreg borders argument works", {
   lm1 <- lm(y ~ a, dfr)
   lm2 <- lm(y ~ b, dfr)
   hr <- huxreg(lm1, lm2, borders = .7, outer_borders = .8)
-  expect_equivalent(unname(brdr_thickness(bottom_border(hr))[, 2]),
-          c(.7, rep(0, 5), .7, rep(0, nrow(hr) - 9), .8, 0))
-  expect_equivalent(unname(brdr_thickness(top_border(hr))[1, ]),
-        matrix(0.8, 1, 3))
+  expect_equivalent(
+    unname(brdr_thickness(bottom_border(hr))[, 2]),
+    c(.7, rep(0, 5), .7, rep(0, nrow(hr) - 9), .8, 0)
+  )
+  expect_equivalent(
+    unname(brdr_thickness(top_border(hr))[1, ]),
+    matrix(0.8, 1, 3)
+  )
   hr2 <- huxreg(lm1, lm2, borders = 0, outer_borders = 0)
-  expect_equivalent(unname(brdr_thickness(bottom_border(hr2)[])),
-        matrix(0, nrow(hr2), ncol(hr2)))
-  expect_equivalent(unname(brdr_thickness(top_border(hr2)[])),
-        matrix(0, nrow(hr2), ncol(hr2)))
+  expect_equivalent(
+    unname(brdr_thickness(bottom_border(hr2)[])),
+    matrix(0, nrow(hr2), ncol(hr2))
+  )
+  expect_equivalent(
+    unname(brdr_thickness(top_border(hr2)[])),
+    matrix(0, nrow(hr2), ncol(hr2))
+  )
 })
 
 
@@ -159,7 +169,8 @@ test_that("huxreg works for models without tidy p values", {
   skip_if_not_installed("broom.mixed")
 
   expect_warning(huxreg(lme4::lmer(Sepal.Width ~ Sepal.Length + (1 | Species), data = iris),
-        statistics = "nobs"), "p values")
+    statistics = "nobs"
+  ), "p values")
 })
 
 
@@ -181,7 +192,7 @@ test_that("huxreg column names are legitimate", {
 
 
 test_that("can pass generics::tidy arguments to huxreg", {
-  lm1 <-  lm(Sepal.Width ~ Sepal.Length, data = iris)
+  lm1 <- lm(Sepal.Width ~ Sepal.Length, data = iris)
   glm1 <- glm(I(Sepal.Width > 3) ~ Sepal.Length, data = iris, family = binomial)
   expect_silent(huxreg(glm1, tidy_args = list(exponentiate = TRUE), statistics = "nobs"))
   expect_silent(huxreg(lm1, glm1, tidy_args = list(list(), list(exponentiate = TRUE)), statistics = "nobs"))
@@ -190,8 +201,8 @@ test_that("can pass generics::tidy arguments to huxreg", {
 
 
 test_that("bugfix: tidy_args works when argument list contains a list", {
-  lm1 <-  lm(Sepal.Width ~ Sepal.Length, data = iris)
-  lm2 <-  lm1
+  lm1 <- lm(Sepal.Width ~ Sepal.Length, data = iris)
+  lm2 <- lm1
   expect_silent(huxreg(lm1, lm2, tidy_args = list(ignored = list())))
 })
 
@@ -199,15 +210,17 @@ test_that("bugfix: tidy_args works when argument list contains a list", {
 test_that("can pass generics::glance arguments to huxreg", {
   skip_if_not_installed("AER")
   iv1 <- AER::ivreg(Sepal.Width ~ Sepal.Length | Petal.Length, data = iris)
-  expect_silent(hr <- huxreg(iv1, glance_args = list(diagnostics = TRUE),
-        statistics = "statistic.Sargan"))
+  expect_silent(hr <- huxreg(iv1,
+    glance_args = list(diagnostics = TRUE),
+    statistics = "statistic.Sargan"
+  ))
 })
 
 
 test_that("tidy_override", {
   skip_if_not_installed("broom")
 
-  lm1 <-  lm(Sepal.Width ~ Sepal.Length, data = iris)
+  lm1 <- lm(Sepal.Width ~ Sepal.Length, data = iris)
 
   fakes <- c(0.0001, 0.048)
   fixed_lm1 <- tidy_override(lm1, p.value = fakes, glance = list(r.squared = 0.95))
@@ -223,7 +236,8 @@ test_that("tidy_override", {
   expect_equivalent(broom::glance(lm1_newcol)$bar, 1)
 
   expect_error(tidy_override(lm1, foo = 1:2, bar = 1:3),
-        info = "Unequal length tidy_override columns should throw an error")
+    info = "Unequal length tidy_override columns should throw an error"
+  )
 })
 
 
@@ -254,11 +268,10 @@ test_that("glance.tidy_override works if underlying object has no glance() metho
 test_that("tidy.tidy_override works if underlying object has no tidy() method", {
   skip_if_not_installed("broom")
   tidy_monster <- tidy_override(
-          list(),
-          term = c("a", "monster"),
-          estimate = c(1, 2),
-          extend = TRUE
-        )
+    list(),
+    term = c("a", "monster"),
+    estimate = c(1, 2),
+    extend = TRUE
+  )
   expect_equivalent(broom::tidy(tidy_monster)$term, c("a", "monster"))
-
 })

--- a/tests/testthat/test-huxtable-creation.R
+++ b/tests/testthat/test-huxtable-creation.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 
@@ -71,14 +69,14 @@ test_that("create huxtable from data frame", {
 
 test_that("autoformat", {
   dfr <- data.frame(
-          character = letters[1:3],
-          integer   = 1:3,
-          numeric   = c(1.5, 2.5, 3.5),
-          complex   = 1:3 + 1i,
-          Date      = as.Date(rep("2001/01/01", 3)),
-          POSIXct   = as.POSIXct(Sys.time()),
-          POSIXlt   = as.POSIXlt(Sys.time())
-        )
+    character = letters[1:3],
+    integer   = 1:3,
+    numeric   = c(1.5, 2.5, 3.5),
+    complex   = 1:3 + 1i,
+    Date      = as.Date(rep("2001/01/01", 3)),
+    POSIXct   = as.POSIXct(Sys.time()),
+    POSIXlt   = as.POSIXlt(Sys.time())
+  )
   ht <- as_hux(dfr, autoformat = TRUE, add_colnames = TRUE)
 
   for (x in c("character", "Date", "POSIXct", "POSIXlt")) {
@@ -124,7 +122,7 @@ test_that("create huxtable from table", {
   tbl <- table(mtcars$gear, mtcars$cyl)
   expect_silent(ht <- as_hux(tbl))
   expect_is(ht, "huxtable")
-  expect_equivalent(ht[[1]][ -1 ], rownames(tbl))
+  expect_equivalent(ht[[1]][-1], rownames(tbl))
   expect_equivalent(unlist(ht[1, -1]), colnames(tbl))
   expect_equivalent(ht[[1, 1]], "") # check no "rownames" in top left
 })

--- a/tests/testthat/test-knit-print.R
+++ b/tests/testthat/test-knit-print.R
@@ -1,11 +1,9 @@
-
-
 skip_if_not_installed("knitr")
 
 
 test_that("Can turn on and off printing of data frames", {
   # NB this all may fail if rmarkdown is loaded; rmarkdown defines knit_print.data.frame :-(
-  expect_huxish <- function (dfr, bool) {
+  expect_huxish <- function(dfr, bool) {
     oo <- options(huxtable.knitr_output_format = "screen")
     tmp <- capture.output(knitr::knit_print(dfr))
     expect_identical(any(grepl("Column names", tmp)), bool)
@@ -22,15 +20,16 @@ test_that("Can turn on and off printing of data frames", {
 })
 
 test_that("Can theme data frames", {
-  mytheme <- function (ht) {
+  mytheme <- function(ht) {
     number_format(ht) <- 5
     ht
   }
 
   oo <- options(
-        huxtable.knitr_output_format = "screen",
-        huxtable.knit_print_df = TRUE,
-        huxtable.knit_print_df_theme = mytheme)
+    huxtable.knitr_output_format = "screen",
+    huxtable.knit_print_df = TRUE,
+    huxtable.knit_print_df_theme = mytheme
+  )
   dfr <- data.frame(a = 1:2, b = 1:2)
   tmp <- knitr::knit_print(dfr)
   expect_true(any(grepl("\\.00000", tmp)))

--- a/tests/testthat/test-latex-dependencies.R
+++ b/tests/testthat/test-latex-dependencies.R
@@ -1,4 +1,3 @@
-
 local_edition(2)
 
 test_that("install/report_latex_dependencies", {
@@ -11,12 +10,16 @@ test_that("install/report_latex_dependencies", {
   packages <- setdiff(packages, c("graphicx", "calc", "array"))
   with_mocked_bindings(
     expect_error(x <- install_latex_dependencies(), regexp = NA),
-    tlmgr_install_wrapper = function (...) return(0)
+    tlmgr_install_wrapper = function(...) {
+      return(0)
+    }
   )
   expect_true(x)
 
-  expect_silent(package_str <- report_latex_dependencies(quiet = TRUE,
-    as_string = TRUE))
+  expect_silent(package_str <- report_latex_dependencies(
+    quiet = TRUE,
+    as_string = TRUE
+  ))
   expect_match(package_str, "\\\\usepackage\\{array\\}")
 })
 
@@ -31,7 +34,7 @@ test_that("check_latex_dependencies checks adjustbox", {
 
   local_mocked_bindings(
     .package = "tinytex",
-    tlmgr = function (...) "1.0",
+    tlmgr = function(...) "1.0",
   )
   expect_warning(check_adjustbox(quiet = FALSE), "adjustbox")
   expect_equivalent(check_adjustbox(), FALSE)
@@ -49,14 +52,18 @@ test_that("check_latex_dependencies runs correctly", {
 
   local_mocked_bindings(
     .package = "tinytex",
-    tl_pkgs = function (...) return(character(0))
+    tl_pkgs = function(...) {
+      return(character(0))
+    }
   )
   expect_false(check_latex_dependencies(quiet = TRUE))
   expect_message(check_latex_dependencies(quiet = FALSE), regexp = "not found")
 
   local_mocked_bindings(
     .package = "tinytex",
-    tl_pkgs = function (...) return(ld)
+    tl_pkgs = function(...) {
+      return(ld)
+    }
   )
   expect_true(check_latex_dependencies(quiet = TRUE))
   expect_message(check_latex_dependencies(quiet = FALSE), regexp = "All LaTeX packages found")

--- a/tests/testthat/test-manipulation-helpers.R
+++ b/tests/testthat/test-manipulation-helpers.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 
@@ -12,8 +10,10 @@ test_that("add_colnames() does not screw up dates and similar", {
   )
   ht <- as_hux(dfr, add_colnames = TRUE)
   ht2 <- add_colnames(as_hux(dfr, add_colnames = FALSE))
-  for (h in list(ht, ht2)) for (col in colnames(dfr)) {
-    expect_match(to_screen(h[, col]), "2015-05-05")
+  for (h in list(ht, ht2)) {
+    for (col in colnames(dfr)) {
+      expect_match(to_screen(h[, col]), "2015-05-05")
+    }
   }
 })
 
@@ -132,7 +132,7 @@ test_that("add_columns and add_rows work with data frames", {
 
 test_that("add_rows and add_columns don't break with matrices", {
   ht <- as_hux(matrix(1, 1, 1))
-  prob <- rbind(ht, rbind(1,1))
+  prob <- rbind(ht, rbind(1, 1))
   expect_equivalent(length(row_height(prob)), 3)
 })
 

--- a/tests/testthat/test-map-interface.R
+++ b/tests/testthat/test-map-interface.R
@@ -1,28 +1,27 @@
-
-
 local_edition(2)
 
 
 test_that("Standard map_xxx", {
-
   ht <- huxtable(
-          Type  = c("Strawberry", "Raspberry", "Plum"),
-          Price = c(1.90, 2.10, 1.80),
-          add_colnames = FALSE
-        )
+    Type = c("Strawberry", "Raspberry", "Plum"),
+    Price = c(1.90, 2.10, 1.80),
+    add_colnames = FALSE
+  )
   align(ht) <- "left"
 
-  test_map <- function (map_fn, result, rows = 1:nrow(ht), cols = 1:ncol(ht)) {
+  test_map <- function(map_fn, result, rows = 1:nrow(ht), cols = 1:ncol(ht)) {
     result <- strsplit(result, "")[[1]]
     result <- c("l" = "left", "c" = "center", "r" = "right")[result]
     expect_equivalent(
-            align(map_align(ht, rows, cols, map_fn)),
-            matrix(result, nrow(ht), ncol(ht))
-          )
+      align(map_align(ht, rows, cols, map_fn)),
+      matrix(result, nrow(ht), ncol(ht))
+    )
   }
 
-  test_map(by_cols("centre", "right"),
-       "cccrrr")
+  test_map(
+    by_cols("centre", "right"),
+    "cccrrr"
+  )
   test_map(by_cols("centre", "right"), "cclrrl", 1:2, 1:2)
   test_map(by_cols("right"), "lllrrr", 1:3, 2)
 
@@ -32,7 +31,7 @@ test_that("Standard map_xxx", {
 
   test_map(by_values(Strawberry = "right", Plum = "right", "centre"), "rcrccc")
 
-  f <- function (x) ifelse(x == "Plum", "center", "right")
+  f <- function(x) ifelse(x == "Plum", "center", "right")
   test_map(by_function(f), "rrcrrr")
 
   test_map(by_regex(".*berry" = "right", "\\." = "centre"), "rrlccc")
@@ -42,13 +41,17 @@ test_that("Standard map_xxx", {
 
   ht_2col <- hux(1:3, 4:6)
   expect_equivalent(
-          align(map_align(ht_2col,
-            by_equal_groups(3, c("left", "center", "right"), colwise = TRUE))),
-          matrix(rep(c("left", "center", "right"), 2), 3, 2)
-        )
+    align(map_align(
+      ht_2col,
+      by_equal_groups(3, c("left", "center", "right"), colwise = TRUE)
+    )),
+    matrix(rep(c("left", "center", "right"), 2), 3, 2)
+  )
   expect_equivalent(
-    align(map_align(ht_2col,
-      by_quantiles(c(.1, .9), c("left", "center", "right"), colwise = TRUE))),
+    align(map_align(
+      ht_2col,
+      by_quantiles(c(.1, .9), c("left", "center", "right"), colwise = TRUE)
+    )),
     matrix(rep(c("left", "center", "right"), 2), 3, 2)
   )
 
@@ -56,8 +59,10 @@ test_that("Standard map_xxx", {
 
   skip_if_not_installed("dplyr")
 
-  test_map(by_cases(. == "Plum" ~ "centre", grepl("berry", .) ~ "right"),
-        "rrclll")
+  test_map(
+    by_cases(. == "Plum" ~ "centre", grepl("berry", .) ~ "right"),
+    "rrclll"
+  )
 
   skip_if_not_installed("scales")
 
@@ -97,8 +102,8 @@ test_that("map_all_*", {
   # what happens when borders overlap!
   m <- matrix(c(1, NA, 2, NA, NA, NA, 2, NA, 1), 3, 3)
   ht <- as_huxtable(m)
-  m1 <- ! is.na(m) & m == 1
-  m2 <- ! is.na(m) & m == 2
+  m1 <- !is.na(m) & m == 1
+  m2 <- !is.na(m) & m == 2
 
   ht2 <- map_all_borders(ht, by_ranges(1.5, c(1, 2)))
   expect_true(all(brdr_thickness(left_border(ht2))[m1] == 1))
@@ -111,30 +116,30 @@ test_that("map_all_*", {
   expect_true(all(brdr_thickness(bottom_border(ht2))[m2] == 2))
 
   ht3 <- map_all_border_colors(ht, by_ranges(1.5, c("red", "black")))
-  expect_true(all(left_border_color(ht3)[m1]   == "red"))
-  expect_true(all(right_border_color(ht3)[m1]  == "red"))
-  expect_true(all(top_border_color(ht3)[m1]    == "red"))
+  expect_true(all(left_border_color(ht3)[m1] == "red"))
+  expect_true(all(right_border_color(ht3)[m1] == "red"))
+  expect_true(all(top_border_color(ht3)[m1] == "red"))
   expect_true(all(bottom_border_color(ht3)[m1] == "red"))
-  expect_true(all(left_border_color(ht3)[m2]   == "black"))
-  expect_true(all(right_border_color(ht3)[m2]  == "black"))
-  expect_true(all(top_border_color(ht3)[m2]    == "black"))
+  expect_true(all(left_border_color(ht3)[m2] == "black"))
+  expect_true(all(right_border_color(ht3)[m2] == "black"))
+  expect_true(all(top_border_color(ht3)[m2] == "black"))
   expect_true(all(bottom_border_color(ht3)[m2] == "black"))
 
 
   ht4 <- map_all_border_styles(ht, by_ranges(1.5, c("solid", "double")))
-  expect_true(all(left_border_style(ht4)[m1]   == "solid"))
-  expect_true(all(right_border_style(ht4)[m1]  == "solid"))
-  expect_true(all(top_border_style(ht4)[m1]    == "solid"))
+  expect_true(all(left_border_style(ht4)[m1] == "solid"))
+  expect_true(all(right_border_style(ht4)[m1] == "solid"))
+  expect_true(all(top_border_style(ht4)[m1] == "solid"))
   expect_true(all(bottom_border_style(ht4)[m1] == "solid"))
-  expect_true(all(left_border_style(ht4)[m2]   == "double"))
-  expect_true(all(right_border_style(ht4)[m2]  == "double"))
-  expect_true(all(top_border_style(ht4)[m2]    == "double"))
+  expect_true(all(left_border_style(ht4)[m2] == "double"))
+  expect_true(all(right_border_style(ht4)[m2] == "double"))
+  expect_true(all(top_border_style(ht4)[m2] == "double"))
   expect_true(all(bottom_border_style(ht4)[m2] == "double"))
 
   ht5 <- map_all_borders(ht, 1:3, 1, by_ranges(1.5, c(1, 2)))
-  expect_equivalent(brdr_thickness(left_border(ht5))[1:3, 1],    c(1, 0, 2))
-  expect_equivalent(brdr_thickness(top_border(ht5))[c(1, 3), 1],    c(1, 2))
-  expect_equivalent(brdr_thickness(right_border(ht5))[1:3, 1],   c(1, 0, 2))
+  expect_equivalent(brdr_thickness(left_border(ht5))[1:3, 1], c(1, 0, 2))
+  expect_equivalent(brdr_thickness(top_border(ht5))[c(1, 3), 1], c(1, 2))
+  expect_equivalent(brdr_thickness(right_border(ht5))[1:3, 1], c(1, 0, 2))
   expect_equivalent(brdr_thickness(bottom_border(ht5))[c(1, 3), 1], c(1, 2))
 
   ht <- as_huxtable(matrix(1:10, 5, 2))
@@ -158,8 +163,6 @@ test_that("map_lr/tb_*", {
   expected <- matrix(ifelse(as.matrix(ht) >= 3, "double", "solid"), 3, 2)
   expect_equivalent(left_border_style(ht3), matrix("solid", 3, 2))
   expect_equivalent(right_border_style(ht3), matrix("solid", 3, 2))
-  expect_equivalent(top_border_style(ht3)[c(1, 3),], expected[c(1, 3),])
-  expect_equivalent(bottom_border_style(ht3)[c(1, 3),], expected[c(1, 3),])
-
+  expect_equivalent(top_border_style(ht3)[c(1, 3), ], expected[c(1, 3), ])
+  expect_equivalent(bottom_border_style(ht3)[c(1, 3), ], expected[c(1, 3), ])
 })
-

--- a/tests/testthat/test-mapping-functions.R
+++ b/tests/testthat/test-mapping-functions.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 
@@ -46,10 +44,14 @@ test_that("by_ranges", {
   f <- by_ranges(breaks = c(2, 6), values = "middle", extend = FALSE)
   expect_equivalent(f(m, 1:2, 1:2, ct), matrix(c(NA, "middle", "middle", NA), 2, 2))
 
-  expect_error(by_ranges(breaks = c(2, 6), values = c("middle", "extra"), extend = FALSE),
-        "length")
-  expect_error(by_ranges(breaks = c(2, 6), values = c("middle", "notenough"), extend = TRUE),
-        "length")
+  expect_error(
+    by_ranges(breaks = c(2, 6), values = c("middle", "extra"), extend = FALSE),
+    "length"
+  )
+  expect_error(
+    by_ranges(breaks = c(2, 6), values = c("middle", "notenough"), extend = TRUE),
+    "length"
+  )
 
   f <- by_ranges(breaks = 3, values = c("low", "high"), right = TRUE)
   expect_equivalent(f(m, 1:2, 1:2, ct), matrix(c("low", "low", "high", "high"), 2, 2))
@@ -62,10 +64,10 @@ test_that("by_quantiles", {
   m <- matrix(1:4, 2, 2)
   ct <- matrix(NA, 2, 2)
 
-  f <- by_quantiles(1:3/4, c("1st", "2nd", "3rd", "4th"))
+  f <- by_quantiles(1:3 / 4, c("1st", "2nd", "3rd", "4th"))
   expect_equivalent(f(m, 1:2, 1:2, ct), matrix(c("1st", "2nd", "3rd", "4th"), 2, 2))
 
-  f <- by_quantiles(1:3/4, c("2nd", "3rd"), extend = FALSE)
+  f <- by_quantiles(1:3 / 4, c("2nd", "3rd"), extend = FALSE)
   expect_equivalent(f(m, 1:2, 1:2, ct), matrix(c(NA, "2nd", "3rd", NA), 2, 2))
 
   expect_error(by_quantiles(c(.5, .25, .75), rep("foo", 4)))
@@ -109,11 +111,11 @@ test_that("by_colorspace", {
 
 
 test_that("by_function", {
-  m <- matrix(1:4/4, 2, 2)
+  m <- matrix(1:4 / 4, 2, 2)
   ct <- matrix(NA, 2, 2)
 
   f <- by_function(grey)
-  expect_equivalent(f(m, 1:2, 1:2, ct), matrix(grey(1:4/4), 2, 2))
+  expect_equivalent(f(m, 1:2, 1:2, ct), matrix(grey(1:4 / 4), 2, 2))
 })
 
 
@@ -124,8 +126,10 @@ test_that("by_cases", {
   ct <- matrix("default", 3, 2)
 
   f <- by_cases(. < 1.5 ~ "small", . == 2 ~ "two", . %in% 3:4 ~ "middle")
-  expect_equivalent(f(m, 1:3, 1:2, ct), matrix(c("small", "two", "middle", "middle", "default",
-        "default"), 3, 2))
+  expect_equivalent(f(m, 1:3, 1:2, ct), matrix(c(
+    "small", "two", "middle", "middle", "default",
+    "default"
+  ), 3, 2))
 
   f <- by_cases(. < 1.5 ~ "small", . == 2 ~ "two", . %in% 3:4 ~ "middle", ignore_na = FALSE)
   expect_equivalent(f(m, 1:3, 1:2, ct), matrix(c("small", "two", "middle", "middle", NA, NA), 3, 2))
@@ -161,7 +165,7 @@ test_that("ignore_na argument works", {
   f <- by_regex("e" = 1, ignore_na = FALSE)
   expect_equivalent(f(m, 1:2, 1:2, ct), matrix(NA, 2, 2))
 
-  always_na <- function (...) NA
+  always_na <- function(...) NA
   f <- by_function(always_na, ignore_na = TRUE)
   expect_equivalent(f(m, 1:2, 1:2, ct), ct)
   f <- by_function(always_na, ignore_na = FALSE)

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -1,5 +1,3 @@
-
-
 md_hux <- hux(x = c(
   "Ordinary text",
   "*Italic*, **bold**",
@@ -56,5 +54,5 @@ test_that("Compile to PDF", {
   skip_on_cran()
 
   md_hux_w <- set_width(md_hux, 0.5)
-  expect_silent(quick_pdf(md_hux_w[1:7,], file = "quick-markdown.pdf", open = FALSE))
+  expect_silent(quick_pdf(md_hux_w[1:7, ], file = "quick-markdown.pdf", open = FALSE))
 })

--- a/tests/testthat/test-merge.R
+++ b/tests/testthat/test-merge.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 
@@ -19,7 +17,6 @@ test_that("merge_cells", {
 
   expect_silent(ht5 <- merge_cells(ht, c(1, 3), 1))
   expect_equivalent(rowspan(ht5), matrix(c(3, 1, 1, 1, 1, 1), 3, 2))
-
 })
 
 

--- a/tests/testthat/test-miscellaneous.R
+++ b/tests/testthat/test-miscellaneous.R
@@ -1,30 +1,30 @@
-
-
 test_that(".onLoad works and sets options", {
   old_opts <- options()
   hux_opts <- list(
-          # huxtable.add_colnames  = NULL, # want not to set this to anything on package load
-          huxtable.print         = NULL,
-          huxtable.color_screen  = NULL,
-          huxtable.knit_print_df_theme = NULL,
-          huxtable.autoformat = NULL,
-          huxtable.autoformat_number_format = NULL,
-          huxtable.autoformat_align = NULL
-        )
+    # huxtable.add_colnames  = NULL, # want not to set this to anything on package load
+    huxtable.print = NULL,
+    huxtable.color_screen = NULL,
+    huxtable.knit_print_df_theme = NULL,
+    huxtable.autoformat = NULL,
+    huxtable.autoformat_number_format = NULL,
+    huxtable.autoformat_align = NULL
+  )
   options(hux_opts)
   expect_silent(huxtable:::.onLoad(system.file(package = "huxtable"), "huxtable"))
   for (opt in names(hux_opts)) {
-    expect_false( is.null(options(opt)[[1]]), info = paste("Option:", opt))
+    expect_false(is.null(options(opt)[[1]]), info = paste("Option:", opt))
   }
   options(old_opts)
 })
 
 
-test_dplyr_methods <- function () {
+test_dplyr_methods <- function() {
   huxtable:::.onLoad(system.file(package = "huxtable"), "huxtable")
-  expected_methods <- c("arrange", "arrange_", "filter", "filter_", "mutate",
-        "mutate_",  "slice", "slice_", "transmute", "transmute_")
-  dplyr_methods <- getNamespaceInfo("dplyr", "S3methods")  # will load dplyr
+  expected_methods <- c(
+    "arrange", "arrange_", "filter", "filter_", "mutate",
+    "mutate_", "slice", "slice_", "transmute", "transmute_"
+  )
+  dplyr_methods <- getNamespaceInfo("dplyr", "S3methods") # will load dplyr
   dplyr_methods <- as.data.frame(dplyr_methods[, 1:2])
   names(dplyr_methods) <- c("generic", "class")
   dplyr_methods <- dplyr::filter(dplyr_methods, class == "huxtable")
@@ -32,7 +32,7 @@ test_dplyr_methods <- function () {
 }
 
 
-test_knitr_methods <- function () {
+test_knitr_methods <- function() {
   huxtable:::.onLoad(system.file(package = "huxtable"), "huxtable")
   knitr_methods <- getNamespaceInfo("knitr", "S3methods")
   knitr_methods <- as.data.frame(knitr_methods[, 1:2])
@@ -47,9 +47,9 @@ test_that(".onLoad gets methods registered if namespace not loaded", {
   skip_if_not_installed("dplyr")
   skip_if_not_installed("knitr")
 
-  tryCatch(unloadNamespace("dplyr"), error = function (e) skip("Couldn't unload dplyr namespace"))
+  tryCatch(unloadNamespace("dplyr"), error = function(e) skip("Couldn't unload dplyr namespace"))
   test_dplyr_methods()
-  tryCatch(unloadNamespace("knitr"), error = function (e) skip("Couldn't unload knitr namespace"))
+  tryCatch(unloadNamespace("knitr"), error = function(e) skip("Couldn't unload knitr namespace"))
   test_knitr_methods()
 })
 
@@ -58,10 +58,10 @@ test_that(".onLoad gets S3 methods registered if namespace loaded", {
   skip_if_not_installed("dplyr")
   skip_if_not_installed("knitr")
 
-  tryCatch(unloadNamespace("dplyr"), error = function (e) skip("Couldn't unload dplyr namespace"))
+  tryCatch(unloadNamespace("dplyr"), error = function(e) skip("Couldn't unload dplyr namespace"))
   library(dplyr)
   test_dplyr_methods()
-  tryCatch(unloadNamespace("knitr"), error = function (e) skip("Couldn't unload knitr namespace"))
+  tryCatch(unloadNamespace("knitr"), error = function(e) skip("Couldn't unload knitr namespace"))
   library(knitr)
   test_knitr_methods()
 })

--- a/tests/testthat/test-new-borders.R
+++ b/tests/testthat/test-new-borders.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 
@@ -52,8 +50,10 @@ test_that("left_border(ht) <- brdr(...)", {
 test_that("left_border(ht)[i,j] <-number", {
   ht <- hux(1:3, 1:3)
   expect_silent(left_border(ht)[1:2, 1] <- 1)
-  expect_equivalent(brdr_thickness(left_border(ht)),
-        matrix(c(1, 1, 0, 0, 0, 0), 3, 2))
+  expect_equivalent(
+    brdr_thickness(left_border(ht)),
+    matrix(c(1, 1, 0, 0, 0, 0), 3, 2)
+  )
 })
 
 
@@ -87,31 +87,43 @@ test_that("set_left_border(ht, brdr)", {
 test_that("set_left_border(ht, row, col, number)", {
   ht <- hux(1:3, 1:3)
   ht2 <- set_left_border(ht, 1, 1, 1)
-  expect_equivalent(brdr_thickness(left_border(ht2)),
-        matrix(c(1, 0, 0, 0, 0, 0), 3, 2))
+  expect_equivalent(
+    brdr_thickness(left_border(ht2)),
+    matrix(c(1, 0, 0, 0, 0, 0), 3, 2)
+  )
 
   ht3 <- set_left_border(ht, everywhere, 1, 1)
-  expect_equivalent(brdr_thickness(left_border(ht3)),
-        matrix(c(1, 1, 1, 0, 0, 0), 3, 2))
+  expect_equivalent(
+    brdr_thickness(left_border(ht3)),
+    matrix(c(1, 1, 1, 0, 0, 0), 3, 2)
+  )
 
   colnames(ht) <- c("a", "b")
   ht4 <- set_left_border(ht, everywhere, "a", 1)
-  expect_equivalent(brdr_thickness(left_border(ht4)),
-        matrix(c(1, 1, 1, 0, 0, 0), 3, 2))
+  expect_equivalent(
+    brdr_thickness(left_border(ht4)),
+    matrix(c(1, 1, 1, 0, 0, 0), 3, 2)
+  )
 
   ht5 <- set_left_border(ht, everywhere, 1)
-  expect_equivalent(brdr_thickness(left_border(ht5)),
-        matrix(c(0.4, 0.4, 0.4, 0, 0, 0), 3, 2))
+  expect_equivalent(
+    brdr_thickness(left_border(ht5)),
+    matrix(c(0.4, 0.4, 0.4, 0, 0, 0), 3, 2)
+  )
 })
 
 
 test_that("set_left_border(ht, row, col, brdr)", {
   ht <- hux(1:3, 1:3)
   ht2 <- set_left_border(ht, 1, 1, brdr(1, "double", "red"))
-  expect_equivalent(brdr_thickness(left_border(ht2)),
-        matrix(c(1, 0, 0, 0, 0, 0), 3, 2))
-  expect_equivalent(left_border_style(ht2),
-        matrix(c("double", rep("solid", 5)), 3, 2))
+  expect_equivalent(
+    brdr_thickness(left_border(ht2)),
+    matrix(c(1, 0, 0, 0, 0, 0), 3, 2)
+  )
+  expect_equivalent(
+    left_border_style(ht2),
+    matrix(c("double", rep("solid", 5)), 3, 2)
+  )
   expect_equivalent(left_border_color(ht2), matrix(c("red", rep(NA, 5)), 3, 2))
 })
 
@@ -125,30 +137,40 @@ test_that("map_left_border", {
   expect_equivalent(brdr_thickness(left_border(ht3)), matrix(c(0, 1, 1, 0), 2, 2))
 
   ht4 <- map_left_border(ht, by_rows(brdr(0), brdr(1)))
-  expect_equivalent(brdr_thickness(left_border(ht4)),
-        matrix(c(0, 1, 0, 1), 2, 2))
+  expect_equivalent(
+    brdr_thickness(left_border(ht4)),
+    matrix(c(0, 1, 0, 1), 2, 2)
+  )
 
   ht5 <- map_left_border(ht, by_cols(brdr(0), brdr(1)))
-  expect_equivalent(brdr_thickness(left_border(ht5)),
-        matrix(c(0, 0, 1, 1), 2, 2))
+  expect_equivalent(
+    brdr_thickness(left_border(ht5)),
+    matrix(c(0, 0, 1, 1), 2, 2)
+  )
 
   # ht8 <- map_left_border(ht, by_cases(. == 2 ~ brdr(1), TRUE ~ brdr(0)))
   # expect_equivalent(left_border(ht8)[], matrix(c(0, 1, 1, 0), 2, 2))
 
   ht9 <- map_left_border(ht, by_quantiles(0.5, list(brdr(0), brdr(1))))
-  expect_equivalent(brdr_thickness(left_border(ht9)),
-        matrix(c(0, 1, 1, 0), 2, 2))
+  expect_equivalent(
+    brdr_thickness(left_border(ht9)),
+    matrix(c(0, 1, 1, 0), 2, 2)
+  )
 
   ht10 <- map_left_border(ht, by_equal_groups(2, list(brdr(0), brdr(1))))
-  expect_equivalent(brdr_thickness(left_border(ht10)),
-        matrix(c(0, 1, 1, 0), 2, 2))
+  expect_equivalent(
+    brdr_thickness(left_border(ht10)),
+    matrix(c(0, 1, 1, 0), 2, 2)
+  )
 
   ht_char <- hux(letters[1:2], letters[2:1])
   ht6 <- map_left_border(ht_char, by_values("a" = brdr(0), "b" = brdr(1)))
-  expect_equivalent(brdr_thickness(left_border(ht6)),
-      matrix(c(0, 1, 1, 0), 2, 2))
+  expect_equivalent(
+    brdr_thickness(left_border(ht6)),
+    matrix(c(0, 1, 1, 0), 2, 2)
+  )
 
-  ht7 <- map_left_border(ht, by_function(function (x) brdr(1)))
+  ht7 <- map_left_border(ht, by_function(function(x) brdr(1)))
   expect_equivalent(brdr_thickness(left_border(ht7)), matrix(1, 2, 2))
 })
 
@@ -199,8 +221,10 @@ test_that("set-multiple with brdr", {
 
   expect_silent(ht3 <- set_all_borders(ht, 1, 1, b))
   # sets right border of (1,1) = left border of (1,2)
-  expect_equivalent(left_border_color(ht3),
-        matrix(c("green", NA, "green", NA), 2, 2))
+  expect_equivalent(
+    left_border_color(ht3),
+    matrix(c("green", NA, "green", NA), 2, 2)
+  )
 
   expect_silent(ht4 <- set_tb_borders(ht, b))
   expect_equivalent(left_border_color(ht4), matrix(NA_character_, 2, 2))
@@ -210,11 +234,15 @@ test_that("set-multiple with brdr", {
 
   expect_silent(ht5 <- set_tb_borders(ht, 1, 1, b))
   expect_equivalent(left_border_color(ht5), matrix(NA_character_, 2, 2))
-  expect_equivalent(top_border_color(ht5),
-        matrix(c("green", "green", NA_character_, NA_character_), 2, 2))
+  expect_equivalent(
+    top_border_color(ht5),
+    matrix(c("green", "green", NA_character_, NA_character_), 2, 2)
+  )
   expect_equivalent(left_border_style(ht5), matrix("solid", 2, 2))
-  expect_equivalent(top_border_style(ht5),
-        matrix(c("dotted", "dotted", "solid", "solid"), 2, 2))
+  expect_equivalent(
+    top_border_style(ht5),
+    matrix(c("dotted", "dotted", "solid", "solid"), 2, 2)
+  )
 
   expect_silent(ht6 <- set_lr_borders(ht, b))
   expect_equivalent(left_border_color(ht6), matrix("green", 2, 2))
@@ -223,11 +251,15 @@ test_that("set-multiple with brdr", {
   expect_equivalent(top_border_style(ht6), matrix("solid", 2, 2))
 
   expect_silent(ht7 <- set_lr_borders(ht, 1, 1, b))
-  expect_equivalent(left_border_color(ht7),
-        matrix(c("green", NA_character_, "green", NA_character_), 2, 2))
+  expect_equivalent(
+    left_border_color(ht7),
+    matrix(c("green", NA_character_, "green", NA_character_), 2, 2)
+  )
   expect_equivalent(top_border_color(ht7), matrix(NA_character_, 2, 2))
-  expect_equivalent(left_border_style(ht7),
-        matrix(c("dotted", "solid", "dotted", "solid"), 2, 2))
+  expect_equivalent(
+    left_border_style(ht7),
+    matrix(c("dotted", "solid", "dotted", "solid"), 2, 2)
+  )
   expect_equivalent(top_border_style(ht7), matrix("solid", 2, 2))
 })
 

--- a/tests/testthat/test-number-format-functions.R
+++ b/tests/testthat/test-number-format-functions.R
@@ -1,4 +1,3 @@
-
 test_that("fmt_percent", {
   ht <- hux(c(0.25, 0.75))
   expect_silent(number_format(ht) <- fmt_percent(1))
@@ -15,12 +14,11 @@ test_that("fmt_pretty", {
   ht <- hux(1:3 * 1e5)
   expect_silent(number_format(ht) <- fmt_pretty())
   expect_match(to_screen(ht), "100,000")
-  expect_silent(number_format(ht)[2,] <- fmt_pretty(big.mark = "_"))
+  expect_silent(number_format(ht)[2, ] <- fmt_pretty(big.mark = "_"))
   expect_match(to_screen(ht), "100,000")
   expect_match(to_screen(ht), "200_000")
-  expect_silent(number_format(ht)[3,] <- 2)
+  expect_silent(number_format(ht)[3, ] <- 2)
   expect_match(to_screen(ht), "100,000")
   expect_match(to_screen(ht), "200_000")
   expect_match(to_screen(ht), "300000.00")
 })
-

--- a/tests/testthat/test-number-formatting.R
+++ b/tests/testthat/test-number-formatting.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 
@@ -42,8 +40,10 @@ test_that("number_format treats scientific notation equivalently to sprintf", {
   number_format(ht) <- 4
   expect_equivalent(huxtable:::clean_contents(ht, "latex")[1, 1], "1120.0000")
   expect_equivalent(huxtable:::clean_contents(ht, "latex")[2, 1], "1120.0000")
-  expect_equivalent(huxtable:::clean_contents(ht, "latex")[3, 1],
-                    "11200000.0000")
+  expect_equivalent(
+    huxtable:::clean_contents(ht, "latex")[3, 1],
+    "11200000.0000"
+  )
   expect_equivalent(huxtable:::clean_contents(ht, "latex")[4, 1], "0.0011")
   # the next is not scientific notation so both numbers should be affected
   expect_equivalent(huxtable:::clean_contents(ht, "latex")[5, 1], "1.1200A3.0000")
@@ -52,45 +52,78 @@ test_that("number_format treats scientific notation equivalently to sprintf", {
 
 
 test_that("number_format works with various interesting cases", {
-  expect_equivalent(huxtable:::format_numbers("1.1234", "%.3f"),
-        "1.123")
-  expect_equivalent(huxtable:::format_numbers("1", "%.3f"),
-        "1.000")
-  expect_equivalent(huxtable:::format_numbers("1 2 3", "%.3f"),
-        "1.000 2.000 3.000")
-  expect_equivalent(huxtable:::format_numbers("1 -2 -3.1 -.4 .5", "%.3f"),
-        "1.000 -2.000 -3.100 -0.400 0.500")
-  expect_equivalent(huxtable:::format_numbers("1.1234-1.1234", "%.3f"),
-        "1.123-1.123")
-  expect_equivalent(huxtable:::format_numbers("1.1234e-2", "%.3f"),
-        "0.011")
-  expect_equivalent(huxtable:::format_numbers("1.1234e-12", "%.3f"),
-        "0.000")
-  expect_equivalent(huxtable:::format_numbers("1.1234e12", "%.3f"),
-        "1123400000000.000")
+  expect_equivalent(
+    huxtable:::format_numbers("1.1234", "%.3f"),
+    "1.123"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("1", "%.3f"),
+    "1.000"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("1 2 3", "%.3f"),
+    "1.000 2.000 3.000"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("1 -2 -3.1 -.4 .5", "%.3f"),
+    "1.000 -2.000 -3.100 -0.400 0.500"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("1.1234-1.1234", "%.3f"),
+    "1.123-1.123"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("1.1234e-2", "%.3f"),
+    "0.011"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("1.1234e-12", "%.3f"),
+    "0.000"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("1.1234e12", "%.3f"),
+    "1123400000000.000"
+  )
   # Make sure user can actually request scientific notation if desired
   # ("e" format) or get them as needed ("g" format)
-  expect_equivalent(huxtable:::format_numbers("1.1234e12", "%.3g"),
-        "1.12e+12")
-  expect_equivalent(huxtable:::format_numbers("1.1234e8 3", "%.3f"),
-        "112340000.000 3.000")
-  expect_equivalent(huxtable:::format_numbers("1.1234e8 3", "%.3g"),
-        "1.12e+08 3")
-  expect_equivalent(huxtable:::format_numbers("1.1234e8 3", "%.1e"),
-        "1.1e+08 3.0e+00")
+  expect_equivalent(
+    huxtable:::format_numbers("1.1234e12", "%.3g"),
+    "1.12e+12"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("1.1234e8 3", "%.3f"),
+    "112340000.000 3.000"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("1.1234e8 3", "%.3g"),
+    "1.12e+08 3"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("1.1234e8 3", "%.1e"),
+    "1.1e+08 3.0e+00"
+  )
   # this is pretty brutal:
-  expect_equivalent(huxtable:::format_numbers("-1.1e3-1.2e3", "%.3f"),
-        "-1100.000-1200.000")
-  expect_equivalent(huxtable:::format_numbers("-1.1e-3-1.2e3", "%.3f"),
-        "-0.001-1200.000")
+  expect_equivalent(
+    huxtable:::format_numbers("-1.1e3-1.2e3", "%.3f"),
+    "-1100.000-1200.000"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("-1.1e-3-1.2e3", "%.3f"),
+    "-0.001-1200.000"
+  )
   # Signed zeroes
-  expect_equivalent(huxtable:::format_numbers("-1.1e-3", "%.1f"),
-        "-0.0")
-  expect_equivalent(huxtable:::format_numbers("-1.1e-3", "%.1g"),
-        "-0.001")
-  expect_equivalent(huxtable:::format_numbers("-1.1e-3", 1),
-        "-0.0")
-
+  expect_equivalent(
+    huxtable:::format_numbers("-1.1e-3", "%.1f"),
+    "-0.0"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("-1.1e-3", "%.1g"),
+    "-0.001"
+  )
+  expect_equivalent(
+    huxtable:::format_numbers("-1.1e-3", 1),
+    "-0.0"
+  )
 })
 
 
@@ -107,13 +140,13 @@ test_that("long_minus", {
 
 test_that("Decimal padding works", {
   expect_identical(
-          huxtable:::handle_decimal_alignment(
-            c("do not pad.", "1.00532", "33", "33.6 *"),
-            c(NA, rep(".", 3)),
-            output_type = "screen"
-          ),
-          c("do not pad.", "1.00532", "33\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0", "33.6 *\u00a0\u00a0")
-        )
+    huxtable:::handle_decimal_alignment(
+      c("do not pad.", "1.00532", "33", "33.6 *"),
+      c(NA, rep(".", 3)),
+      output_type = "screen"
+    ),
+    c("do not pad.", "1.00532", "33\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0", "33.6 *\u00a0\u00a0")
+  )
   # the characters are non-breaking spaces
 })
 

--- a/tests/testthat/test-object-manipulation.R
+++ b/tests/testthat/test-object-manipulation.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 

--- a/tests/testthat/test-openxlsx.R
+++ b/tests/testthat/test-openxlsx.R
@@ -1,5 +1,3 @@
-
-
 skip_if_not_installed("openxlsx")
 
 
@@ -24,10 +22,10 @@ test_that("Text properties work", {
 
 test_that("Borders work", {
   hx <- huxtable(a = 1:3, b = 4:6)
-  top_border(hx)[1, ]    <- 1
+  top_border(hx)[1, ] <- 1
   bottom_border(hx)[1, ] <- 2
-  left_border(hx)[, 1]   <- 1
-  right_border(hx)[, 2]  <- 1
+  left_border(hx)[, 1] <- 1
+  right_border(hx)[, 2] <- 1
   expect_silent(as_Workbook(hx))
 })
 
@@ -40,9 +38,9 @@ test_that("Widths and alignment work", {
   row_height(hx) <- c(.2, .6, .2)
   height(hx) <- .8
   expect_silent(as_Workbook(hx))
-  align(hx)[1, 1]  <- "right"
+  align(hx)[1, 1] <- "right"
   valign(hx)[1, 2] <- "middle"
-  align(hx)[2, 1]  <- "centre"
+  align(hx)[2, 1] <- "centre"
   expect_silent(as_Workbook(hx))
 })
 
@@ -112,7 +110,8 @@ test_that("Data written in appropriate format", {
   hx <- huxtable(a = 1:2 + 0.5, b = -1:-2 + 0.5, d = letters[1:2], add_colnames = TRUE)
   wb <- as_Workbook(hx)
   expect_error(openxlsx::saveWorkbook(wb, file = "test-xlsx.xlsx", overwrite = TRUE),
-        regexp = NA) # openxlsx may emit messages
+    regexp = NA
+  ) # openxlsx may emit messages
   on.exit(
     if (file.exists("test-xlsx.xlsx")) file.remove("test-xlsx.xlsx")
   )

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -1,14 +1,13 @@
-
-
 local_edition(2)
 
 
 test_that("to_screen gives warning with colour if crayon not installed", {
   ht <- hux(a = 1:2)
-  with_mocked_bindings({
+  with_mocked_bindings(
+    {
       expect_warning(to_screen(ht, color = TRUE), "crayon")
     },
-    requireNamespace = function (...) FALSE
+    requireNamespace = function(...) FALSE
   )
 })
 
@@ -39,8 +38,8 @@ test_that("to_md and to_screen keep to min_width", {
       output <- func(ht, min_width = mw)
       lines <- strsplit(output, "\n", fixed = TRUE)[[1]]
       lines <- lines[nchar(lines) > 0] # empty lines after table itself
-      lines <- lines[ ! grepl("Column names", lines)]
-      expect_true(all(nchar(lines, type = "width") >= mw ))
+      lines <- lines[!grepl("Column names", lines)]
+      expect_true(all(nchar(lines, type = "width") >= mw))
     }
   }
 })
@@ -101,8 +100,9 @@ test_that("to_screen borders respect spans", {
   # a line with just: some spaces, │, 1, some spaces, │, some spaces
   # NB that this character: │ is NOT the "or" character, so don't try to type it
   expect_match(to_screen(ht),
-        "\\n\\s*│\\s*1\\s*│\\s*\\n",
-        perl = TRUE)
+    "\\n\\s*│\\s*1\\s*│\\s*\\n",
+    perl = TRUE
+  )
 
   rowspan(ht2)[1, 1] <- 2
   # a line after "3" with some spaces, a │ and some more spaces
@@ -135,8 +135,10 @@ test_that("hux_logo works", {
 
 
 test_that("Multi-rowspan screen output is sane", {
-  ht <- hux(a = rep("aaaaaa", 10), b = rep("bbbbbb", 10),
-            add_colnames = TRUE)
+  ht <- hux(
+    a = rep("aaaaaa", 10), b = rep("bbbbbb", 10),
+    add_colnames = TRUE
+  )
   rowspan(ht)[1, 1] <- 10
   expect_equal_to_reference(to_screen(ht), "multirow.rds")
 })

--- a/tests/testthat/test-quick-output.R
+++ b/tests/testthat/test-quick-output.R
@@ -1,11 +1,9 @@
-
-
-skip_without_latex_deps <- function () {
+skip_without_latex_deps <- function() {
   skip_on_cran() # CRAN doesn't play nicely with tinytex, it uses full texlive
   skip_if_not(
-          requireNamespace("tinytex", quietly = TRUE) ||
-          check_latex_dependencies(quiet = TRUE)
-        )
+    requireNamespace("tinytex", quietly = TRUE) ||
+      check_latex_dependencies(quiet = TRUE)
+  )
 }
 
 

--- a/tests/testthat/test-restack-split.R
+++ b/tests/testthat/test-restack-split.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 
@@ -43,13 +41,13 @@ test_that("split_down tidyselect", {
 
 test_that("split width/height", {
   square <- as_hux(matrix(1:16, 4, 4))
-  col_width(square)  <- c(.2, .3, .3, .2)
+  col_width(square) <- c(.2, .3, .3, .2)
   row_height(square) <- c(.2, .3, .3, .2)
 
   expect_equivalent(
-          split_down(square, after = 2),
-          split_down(square, width = 0.5)
-        )
+    split_down(square, after = 2),
+    split_down(square, width = 0.5)
+  )
   expect_equivalent(
     split_across(square, after = 2),
     split_across(square, height = 0.5)
@@ -86,17 +84,17 @@ test_that("basic restack", {
 
 
 test_that("restack headers", {
-  jams_l <- jams[c(1,2,3,4,4), ]
+  jams_l <- jams[c(1, 2, 3, 4, 4), ]
   expect_silent(wide_jams <- restack_across(jams_l, 3))
   expect_equivalent(
-          as.character(wide_jams[1, ]),
-          rep(c("Type", "Price"), 2)
-        )
+    as.character(wide_jams[1, ]),
+    rep(c("Type", "Price"), 2)
+  )
   expect_equivalent(header_rows(wide_jams), c(TRUE, FALSE, FALSE))
 
   expect_silent(jw2 <- restack_across(jams, 2, headers = FALSE))
   expect_equivalent(
-          as.character(jw2[1, 1:3]),
-          c("Type", "Price", "Raspberry")
-        )
+    as.character(jw2[1, 1:3]),
+    c("Type", "Price", "Raspberry")
+  )
 })

--- a/tests/testthat/test-row-col-functions.R
+++ b/tests/testthat/test-row-col-functions.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 

--- a/tests/testthat/test-set-interface.R
+++ b/tests/testthat/test-set-interface.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 

--- a/tests/testthat/test-set-multiple.R
+++ b/tests/testthat/test-set-multiple.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 
@@ -9,14 +7,14 @@ test_that("set_all_*", {
   expect_equivalent(brdr_thickness(top_border(ht2)), matrix(1, 2, 2))
 
   ht4 <- set_all_borders(ht, 1, 2, 1)
-  expect_equivalent(brdr_thickness(top_border(ht4))[1, 2],    1)
-  expect_equivalent(brdr_thickness(left_border(ht4))[1, 2],   1)
+  expect_equivalent(brdr_thickness(top_border(ht4))[1, 2], 1)
+  expect_equivalent(brdr_thickness(left_border(ht4))[1, 2], 1)
   expect_equivalent(brdr_thickness(bottom_border(ht4))[1, 2], 1)
-  expect_equivalent(brdr_thickness(right_border(ht4))[1, 2],  1)
-  expect_equivalent(brdr_thickness(top_border(ht4))[2, 1],    0)
-  expect_equivalent(brdr_thickness(left_border(ht4))[2, 1],   0)
+  expect_equivalent(brdr_thickness(right_border(ht4))[1, 2], 1)
+  expect_equivalent(brdr_thickness(top_border(ht4))[2, 1], 0)
+  expect_equivalent(brdr_thickness(left_border(ht4))[2, 1], 0)
   expect_equivalent(brdr_thickness(bottom_border(ht4))[2, 1], 0)
-  expect_equivalent(brdr_thickness(right_border(ht4))[2, 1],  0)
+  expect_equivalent(brdr_thickness(right_border(ht4))[2, 1], 0)
 
   rownum <- 1
   colnum <- 2
@@ -37,48 +35,74 @@ test_that("set_all_*", {
 
 test_that("set_lr/tb_* functions", {
   ht <- hux(a = 1:2, b = 1:2, add_colnames = FALSE)
-  expect_equivalent(brdr_thickness(left_border(set_lr_borders(ht))),   matrix(0.4, 2, 2))
-  expect_equivalent(brdr_thickness(right_border(set_lr_borders(ht))),  matrix(0.4, 2, 2))
-  expect_equivalent(brdr_thickness(top_border(set_lr_borders(ht))),    matrix(0, 2, 2))
+  expect_equivalent(brdr_thickness(left_border(set_lr_borders(ht))), matrix(0.4, 2, 2))
+  expect_equivalent(brdr_thickness(right_border(set_lr_borders(ht))), matrix(0.4, 2, 2))
+  expect_equivalent(brdr_thickness(top_border(set_lr_borders(ht))), matrix(0, 2, 2))
   expect_equivalent(brdr_thickness(bottom_border(set_lr_borders(ht))), matrix(0, 2, 2))
 
-  expect_equivalent(brdr_thickness(left_border(set_tb_borders(ht))),   matrix(0, 2, 2))
-  expect_equivalent(brdr_thickness(right_border(set_tb_borders(ht))),  matrix(0, 2, 2))
-  expect_equivalent(brdr_thickness(top_border(set_tb_borders(ht))),    matrix(0.4, 2, 2))
+  expect_equivalent(brdr_thickness(left_border(set_tb_borders(ht))), matrix(0, 2, 2))
+  expect_equivalent(brdr_thickness(right_border(set_tb_borders(ht))), matrix(0, 2, 2))
+  expect_equivalent(brdr_thickness(top_border(set_tb_borders(ht))), matrix(0.4, 2, 2))
   expect_equivalent(brdr_thickness(bottom_border(set_tb_borders(ht))), matrix(0.4, 2, 2))
 
-  expect_equivalent(left_border_color(set_lr_border_colors(ht, "red")),   matrix("red", 2, 2))
-  expect_equivalent(right_border_color(set_lr_border_colors(ht, "red")),  matrix("red", 2, 2))
-  expect_equivalent(top_border_color(set_lr_border_colors(ht, "red")),    matrix(NA_character_, 2, 2))
-  expect_equivalent(bottom_border_color(set_lr_border_colors(ht, "red")),
-        matrix(NA_character_, 2, 2))
+  expect_equivalent(left_border_color(set_lr_border_colors(ht, "red")), matrix("red", 2, 2))
+  expect_equivalent(right_border_color(set_lr_border_colors(ht, "red")), matrix("red", 2, 2))
+  expect_equivalent(top_border_color(set_lr_border_colors(ht, "red")), matrix(NA_character_, 2, 2))
+  expect_equivalent(
+    bottom_border_color(set_lr_border_colors(ht, "red")),
+    matrix(NA_character_, 2, 2)
+  )
 
-  expect_equivalent(left_border_color(set_tb_border_colors(ht, "red")),
-        matrix(NA_character_, 2, 2))
-  expect_equivalent(right_border_color(set_tb_border_colors(ht, "red")),
-        matrix(NA_character_, 2, 2))
-  expect_equivalent(top_border_color(set_tb_border_colors(ht, "red")),
-        matrix("red", 2, 2))
-  expect_equivalent(bottom_border_color(set_tb_border_colors(ht, "red")),
-        matrix("red", 2, 2))
+  expect_equivalent(
+    left_border_color(set_tb_border_colors(ht, "red")),
+    matrix(NA_character_, 2, 2)
+  )
+  expect_equivalent(
+    right_border_color(set_tb_border_colors(ht, "red")),
+    matrix(NA_character_, 2, 2)
+  )
+  expect_equivalent(
+    top_border_color(set_tb_border_colors(ht, "red")),
+    matrix("red", 2, 2)
+  )
+  expect_equivalent(
+    bottom_border_color(set_tb_border_colors(ht, "red")),
+    matrix("red", 2, 2)
+  )
 
-  expect_equivalent(left_border_style(set_lr_border_styles(ht, "double")),
-        matrix("double", 2, 2))
-  expect_equivalent(right_border_style(set_lr_border_styles(ht, "double")),
-        matrix("double", 2, 2))
-  expect_equivalent(top_border_style(set_lr_border_styles(ht, "double")),
-        matrix("solid", 2, 2))
-  expect_equivalent(bottom_border_style(set_lr_border_styles(ht, "double")),
-        matrix("solid", 2, 2))
+  expect_equivalent(
+    left_border_style(set_lr_border_styles(ht, "double")),
+    matrix("double", 2, 2)
+  )
+  expect_equivalent(
+    right_border_style(set_lr_border_styles(ht, "double")),
+    matrix("double", 2, 2)
+  )
+  expect_equivalent(
+    top_border_style(set_lr_border_styles(ht, "double")),
+    matrix("solid", 2, 2)
+  )
+  expect_equivalent(
+    bottom_border_style(set_lr_border_styles(ht, "double")),
+    matrix("solid", 2, 2)
+  )
 
-  expect_equivalent(left_border_style(set_tb_border_styles(ht, "double")),
-        matrix("solid", 2, 2))
-  expect_equivalent(right_border_style(set_tb_border_styles(ht, "double")),
-        matrix("solid", 2, 2))
-  expect_equivalent(top_border_style(set_tb_border_styles(ht, "double")),
-        matrix("double", 2, 2))
-  expect_equivalent(bottom_border_style(set_tb_border_styles(ht, "double")),
-        matrix("double", 2, 2))
+  expect_equivalent(
+    left_border_style(set_tb_border_styles(ht, "double")),
+    matrix("solid", 2, 2)
+  )
+  expect_equivalent(
+    right_border_style(set_tb_border_styles(ht, "double")),
+    matrix("solid", 2, 2)
+  )
+  expect_equivalent(
+    top_border_style(set_tb_border_styles(ht, "double")),
+    matrix("double", 2, 2)
+  )
+  expect_equivalent(
+    bottom_border_style(set_tb_border_styles(ht, "double")),
+    matrix("double", 2, 2)
+  )
 })
 
 
@@ -102,18 +126,26 @@ test_that("set_all_* functions work when huxtable is not attached", {
 test_that("set_outer_*", {
   ht <- hux(a = 1:3, b = 1:3, c = 1:3)
 
-  check_borders <- function (ht, suffix, un, set) {
+  check_borders <- function(ht, suffix, un, set) {
     wrapper <- if (suffix == "") brdr_thickness else identity
     funcs <- paste0(c("top", "bottom", "left", "right"), sprintf("_border%s", suffix))
     funcs <- mget(funcs, inherits = TRUE)
-    expect_equivalent(wrapper(funcs[[1]](ht)),
-          matrix(c(un, un, un, un, set, un, un, set, un), 3, 3))
-    expect_equivalent(wrapper(funcs[[2]](ht)),
-          matrix(c(un, un, un, set, un, set, set, un, set), 3, 3))
-    expect_equivalent(wrapper(funcs[[3]](ht)),
-          matrix(c(un, un, un, un, set, set, un, un, un), 3, 3))
-    expect_equivalent(wrapper(funcs[[4]](ht)),
-          matrix(c(un, set, set, un, un, un, un, set, set), 3, 3))
+    expect_equivalent(
+      wrapper(funcs[[1]](ht)),
+      matrix(c(un, un, un, un, set, un, un, set, un), 3, 3)
+    )
+    expect_equivalent(
+      wrapper(funcs[[2]](ht)),
+      matrix(c(un, un, un, set, un, set, set, un, set), 3, 3)
+    )
+    expect_equivalent(
+      wrapper(funcs[[3]](ht)),
+      matrix(c(un, un, un, un, set, set, un, un, un), 3, 3)
+    )
+    expect_equivalent(
+      wrapper(funcs[[4]](ht)),
+      matrix(c(un, set, set, un, un, un, un, set, set), 3, 3)
+    )
   }
 
   ht2 <- set_outer_borders(ht, 2:3, 2:3, 1)
@@ -171,16 +203,16 @@ test_that("set_outer_borders() works with non-standard/empty position arguments"
 test_that("set_outer_padding", {
   ht <- hux(1:2, 1:2)
   ht2 <- set_outer_padding(ht, 10)
-  expect_equivalent(left_padding(ht2),   matrix(c(10, 10, 6, 6), 2, 2))
-  expect_equivalent(top_padding(ht2),    matrix(c(10, 6, 10, 6), 2, 2))
+  expect_equivalent(left_padding(ht2), matrix(c(10, 10, 6, 6), 2, 2))
+  expect_equivalent(top_padding(ht2), matrix(c(10, 6, 10, 6), 2, 2))
   expect_equivalent(bottom_padding(ht2), matrix(c(6, 10, 6, 10), 2, 2))
-  expect_equivalent(right_padding(ht2),  matrix(c(6, 6, 10, 10), 2, 2))
+  expect_equivalent(right_padding(ht2), matrix(c(6, 6, 10, 10), 2, 2))
 
   ht3 <- set_outer_padding(ht, 2, 2, 10)
-  expect_equivalent(left_padding(ht3),   matrix(c(6, 6, 6, 10), 2, 2))
-  expect_equivalent(top_padding(ht3),    matrix(c(6, 6, 6, 10), 2, 2))
+  expect_equivalent(left_padding(ht3), matrix(c(6, 6, 6, 10), 2, 2))
+  expect_equivalent(top_padding(ht3), matrix(c(6, 6, 6, 10), 2, 2))
   expect_equivalent(bottom_padding(ht3), matrix(c(6, 6, 6, 10), 2, 2))
-  expect_equivalent(right_padding(ht3),   matrix(c(6, 6, 6, 10), 2, 2))
+  expect_equivalent(right_padding(ht3), matrix(c(6, 6, 6, 10), 2, 2))
 })
 
 test_that("set_markdown_contents", {

--- a/tests/testthat/test-stripes.R
+++ b/tests/testthat/test-stripes.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 

--- a/tests/testthat/test-style.R
+++ b/tests/testthat/test-style.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 
@@ -58,7 +56,3 @@ test_that("style_headers et al.", {
   ht <- style_header_cols(ht, bold = TRUE)
   expect_equivalent(bold(ht), matrix(c(TRUE, FALSE), 1, 2))
 })
-
-
-
-

--- a/tests/testthat/test-subset-replace.R
+++ b/tests/testthat/test-subset-replace.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 
@@ -28,7 +26,7 @@ test_that("Zero-argument [<-", {
   expect_identical(ht[[3, 2]], 6L)
 
   ht <- hux(a = 1:2, b = 1:2, add_colnames = TRUE)
-  expect_silent(ht[ , ] <- matrix(1:6, 3, 2))
+  expect_silent(ht[, ] <- matrix(1:6, 3, 2))
   expect_identical(ht[[3, 2]], 6L)
 })
 
@@ -122,7 +120,7 @@ test_that("Can delete columns from a huxtable by setting it to `NULL`", {
   # this kind of subsetting doesn't seem to work in earlier Rs
   if (getRversion() >= "3.3.3") {
     ht4 <- hux(a = 1:2, b = 1:2, c = 1:2)
-    expect_silent(ht4[ c("a", "b")] <- NULL)
+    expect_silent(ht4[c("a", "b")] <- NULL)
     expect_equivalent(font(ht4), matrix(NA_character_, 2, 1))
     expect_equivalent(col_width(ht4), NA_real_)
 

--- a/tests/testthat/test-subset-spans.R
+++ b/tests/testthat/test-subset-spans.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 
@@ -28,7 +26,7 @@ test_that("Copying a whole span creates two separate spans", {
   expect_equivalent(rowspan(ht2)[3, 1], 2)
 
   ht3 <- hux(a = 1:2, b = 1:2)
-  expect_silent(ht4 <- ht3[c(1,1), ])
+  expect_silent(ht4 <- ht3[c(1, 1), ])
   expect_equivalent(colspan(ht4)[1, 1], 1)
 })
 

--- a/tests/testthat/test-themes.R
+++ b/tests/testthat/test-themes.R
@@ -1,4 +1,3 @@
-
 test_that("Themes work", {
   ht <- huxtable(a = 1:5, b = 1:5)
   expect_error(theme_basic(ht), regexp = NA)
@@ -18,7 +17,8 @@ test_that("Themes work with options", {
   ht <- huxtable(a = 1:5, b = 1:5, add_colnames = TRUE)
   expect_error(theme_basic(ht, header_rows = FALSE, header_cols = FALSE), regexp = NA)
   expect_error(theme_striped(ht, stripe = "purple", header_rows = FALSE, header_cols = FALSE),
-        regexp = NA)
+    regexp = NA
+  )
   expect_silent(theme_bright(ht, header_rows = FALSE, header_cols = TRUE))
   expect_error(theme_article(ht, header_rows = FALSE, header_cols = FALSE), regexp = NA)
   expect_silent(theme_compact(ht, header_rows = TRUE))

--- a/tests/testthat/test-yy-end-to-end.R
+++ b/tests/testthat/test-yy-end-to-end.R
@@ -1,4 +1,3 @@
-
 skip_if_not_installed("knitr")
 skip_if_not_installed("rmarkdown")
 skip_without_pandoc()
@@ -21,25 +20,26 @@ validate_markdown <- function(md_string) {
   })
 
   tf <- tempfile(
-          pattern = "markdown-example",
-          fileext = ".md",
-          tmpdir = "temp-artefacts"
-        )
+    pattern = "markdown-example",
+    fileext = ".md",
+    tmpdir = "temp-artefacts"
+  )
   cat(md_string, file = tf)
 
   expect_silent(
-    outfile  <- rmarkdown::render(tf,
-                  output_format     = rmarkdown::html_document(
-                                        pandoc_args = c("--metadata",
-                                          "title=\"Avoid warnings\""
-                                        )
-                                      ),
-                  output_file       = NULL,
-                  output_dir        = "temp-artefacts",
-                  intermediates_dir = "temp-artefacts",
-                  clean             = TRUE,
-                  quiet             = TRUE
-                )
+    outfile <- rmarkdown::render(tf,
+      output_format = rmarkdown::html_document(
+        pandoc_args = c(
+          "--metadata",
+          "title=\"Avoid warnings\""
+        )
+      ),
+      output_file = NULL,
+      output_dir = "temp-artefacts",
+      intermediates_dir = "temp-artefacts",
+      clean = TRUE,
+      quiet = TRUE
+    )
   )
 }
 
@@ -52,14 +52,15 @@ test_render <- function(path, format, output_dir = "temp-artefacts") {
     options(oo)
     if (file.exists(output)) try(file.remove(output), silent = TRUE)
   })
-  expect_error(output <- rmarkdown::render(path,
-          output_format     = format,
-          quiet             = TRUE,
-          output_dir        = output_dir,
-          intermediates_dir = "temp-artefacts"
-        ),
+  expect_error(
+    output <- rmarkdown::render(path,
+      output_format     = format,
+      quiet             = TRUE,
+      output_dir        = output_dir,
+      intermediates_dir = "temp-artefacts"
+    ),
     regexp = NA,
-    info   = list(path = path, format = format)
+    info = list(path = path, format = format)
   )
 }
 
@@ -86,8 +87,10 @@ test_that("Can knit .Rhtml files to HTML", {
   on.exit(try(file.remove(output_files), silent = TRUE))
   for (i in seq_along(in_files)) {
     expect_error(
-      output_files[i] <- knitr::knit(in_files[i], output = output_files[i],
-            quiet = TRUE),
+      output_files[i] <- knitr::knit(in_files[i],
+        output = output_files[i],
+        quiet = TRUE
+      ),
       regexp = NA
     )
     expect_true(file.exists(output_files[i]))
@@ -99,24 +102,26 @@ test_that("guess_knitr_output_format() gets it right", {
   skip_on_cran()
   out <- character(0)
   on.exit({
-    lapply(out, function (x) {
+    lapply(out, function(x) {
       if (file.exists(x)) try(file.remove(x), silent = TRUE)
     })
   })
   expect_silent(out[1] <- knitr::knit("guess-output-format-test.Rhtml",
-        quiet = TRUE))
+    quiet = TRUE
+  ))
   expect_silent(out[2] <- knitr::knit("guess-output-format-test.Rnw",
-        quiet = TRUE))
+    quiet = TRUE
+  ))
 
   test_render("guess-output-format-test-Rmd-html.Rmd", "html_document")
   test_render("guess-output-format-test-Rmd-pdf.Rmd", "pdf_document")
-
 })
 
 
 test_that("Four spaces does not cause <pre><code> markup", {
   output <- rmarkdown::render("fourspace-html-test.Rmd",
-        output_dir = "temp-artefacts", quiet = TRUE)
+    output_dir = "temp-artefacts", quiet = TRUE
+  )
   on.exit(if (exists("output")) try(file.remove(output), silent = TRUE))
   lines <- readLines(output)
   expect_false(any(grepl("findme&lt;/td&gt;", lines)))
@@ -140,7 +145,7 @@ test_that("echo = TRUE does not cause option clash", {
 test_that("Various Rmd files render without errors", {
   skip_on_cran()
 
-  test_render_all <- function (path) {
+  test_render_all <- function(path) {
     test_render(path, "pdf_document")
     test_render(path, "html_document")
   }
@@ -175,8 +180,9 @@ test_that("quarto files", {
   skip_if_not(is.character(qp))
 
   on.exit({
-    for (f in c("quarto-test-out.pdf", "quarto-test-out.html"))
-    if (file.exists(f)) try(file.remove(f), silent = TRUE)
+    for (f in c("quarto-test-out.pdf", "quarto-test-out.html")) {
+      if (file.exists(f)) try(file.remove(f), silent = TRUE)
+    }
     if (file.exists("quarto-test_files")) {
       try(unlink("quarto-test_files", recursive = TRUE), silent = TRUE)
     }
@@ -184,35 +190,42 @@ test_that("quarto files", {
 
   if (quarto::quarto_version() < "1.4") {
     expect_silent(
-      quarto::quarto_render("quarto-test.qmd", output_format = "pdf",
-                              output_file = "quarto-test-out.pdf",
-                              execute_dir = "temp-artefacts",
-                              debug = FALSE, quiet = TRUE)
+      quarto::quarto_render("quarto-test.qmd",
+        output_format = "pdf",
+        output_file = "quarto-test-out.pdf",
+        execute_dir = "temp-artefacts",
+        debug = FALSE, quiet = TRUE
+      )
     )
   } else {
     # for some reason (probably due to use of processx::) I can't
     # capture the specific huxtable error from make_label() here
     expect_error(
-      quarto::quarto_render("quarto-test.qmd", output_format = "pdf",
-                              output_file = "quarto-test-out.pdf",
-                              execute_dir = "temp-artefacts",
-                              debug = FALSE, quiet = TRUE)
+      quarto::quarto_render("quarto-test.qmd",
+        output_format = "pdf",
+        output_file = "quarto-test-out.pdf",
+        execute_dir = "temp-artefacts",
+        debug = FALSE, quiet = TRUE
+      )
     )
     expect_silent(
-      quarto::quarto_render("quarto-test-tex-labels.qmd", output_format = "pdf",
-                              output_file = "quarto-test-tex-labels-out.pdf",
-                              execute_dir = "temp-artefacts",
-                              debug = FALSE, quiet = TRUE)
+      quarto::quarto_render("quarto-test-tex-labels.qmd",
+        output_format = "pdf",
+        output_file = "quarto-test-tex-labels-out.pdf",
+        execute_dir = "temp-artefacts",
+        debug = FALSE, quiet = TRUE
+      )
     )
   }
 
   expect_silent(
-    quarto::quarto_render("quarto-test.qmd", output_format = "html",
-                            output_file = "quarto-test-out.html",
-                            execute_dir = "temp-artefacts",
-                            debug = FALSE, quiet = TRUE)
+    quarto::quarto_render("quarto-test.qmd",
+      output_format = "html",
+      output_file = "quarto-test-out.html",
+      execute_dir = "temp-artefacts",
+      debug = FALSE, quiet = TRUE
+    )
   )
-
 })
 
 
@@ -234,25 +247,32 @@ test_that("huxtable.long_minus", {
   expect_silent(to_md(ht))
 
   expect_silent(quick_html(ht,
-        file = file.path("temp-artefacts", "long-minus-test.html"), open = FALSE))
+    file = file.path("temp-artefacts", "long-minus-test.html"), open = FALSE
+  ))
   expect_silent(quick_latex(ht,
-        file = file.path("temp-artefacts", "long-minus-test.tex"), open = FALSE))
+    file = file.path("temp-artefacts", "long-minus-test.tex"), open = FALSE
+  ))
   expect_silent(quick_rtf(ht,
-        file = file.path("temp-artefacts", "long-minus-test.rtf"), open = FALSE))
+    file = file.path("temp-artefacts", "long-minus-test.rtf"), open = FALSE
+  ))
 
   skip_if_not_installed("openxlsx")
   expect_silent(quick_xlsx(ht,
-        file = file.path("temp-artefacts", "long-minus-test.xlsx"), open = FALSE))
+    file = file.path("temp-artefacts", "long-minus-test.xlsx"), open = FALSE
+  ))
 
   skip_if_not_installed("flextable")
   expect_silent(quick_docx(ht,
-        file = file.path("temp-artefacts", "long-minus-test.docx"), open = FALSE))
+    file = file.path("temp-artefacts", "long-minus-test.docx"), open = FALSE
+  ))
   expect_silent(quick_pptx(ht,
-        file = file.path("temp-artefacts", "long-minus-test.pptx"), open = FALSE))
+    file = file.path("temp-artefacts", "long-minus-test.pptx"), open = FALSE
+  ))
 
   skip_on_cran()
   expect_silent(quick_pdf(ht,
-        file = file.path("temp-artefacts", "long-minus-test.pdf"), open = FALSE))
+    file = file.path("temp-artefacts", "long-minus-test.pdf"), open = FALSE
+  ))
 })
 
 

--- a/tests/testthat/test-zz-fuzz.R
+++ b/tests/testthat/test-zz-fuzz.R
@@ -1,5 +1,3 @@
-
-
 local_edition(2)
 
 
@@ -14,18 +12,21 @@ local_edition(2)
 # cat(readRDS("tests/testthat/output-rds/various-outputs-six_figure_no-..."))
 # or run quick_xxx functions on it
 
-expect_outputs_unchanged <- function (hx, idx) {
+expect_outputs_unchanged <- function(hx, idx) {
   info <- paste0("Index i = ", idx)
   file <- file.path(test_path(), "output-rds", paste0("various-outputs-", idx))
   # setting the width avoids problems that command line and RStudio tests have different
   # options(width)
   expect_known_value(to_screen(hx, min_width = 20, max_width = 80),
-        file = paste0(file, "-screen.rds"), info = info)
-  expect_known_value(to_md(hx, min_width = 20, max_width = 80), file = paste0(file, "-md.rds"),
-        info = info)
-  expect_known_value(to_html(hx),   file = paste0(file, "-html.rds"),   info = info)
-  expect_known_value(to_latex(hx),  file = paste0(file, "-latex.rds"),  info = info)
-  expect_known_value(to_rtf(hx),  file = paste0(file, "-rtf.rds"),  info = info)
+    file = paste0(file, "-screen.rds"), info = info
+  )
+  expect_known_value(to_md(hx, min_width = 20, max_width = 80),
+    file = paste0(file, "-md.rds"),
+    info = info
+  )
+  expect_known_value(to_html(hx), file = paste0(file, "-html.rds"), info = info)
+  expect_known_value(to_latex(hx), file = paste0(file, "-latex.rds"), info = info)
+  expect_known_value(to_rtf(hx), file = paste0(file, "-rtf.rds"), info = info)
 }
 
 
@@ -52,7 +53,7 @@ variations <- expand.grid(
 variations$left_border[variations$left_border_style == "double"] <- 3
 
 hx_raw <- hux(
-  int  = 1:3,
+  int = 1:3,
   real = 1:3 + 0.005,
   char = letters[1:3],
   date = as.Date(1:3, origin = "1970-01-01"),
@@ -64,7 +65,7 @@ hx_raw <- hux(
 add_props <- function(hx, row) {
   props <- as.list(row)
   props$ht <- hx
-  props_no_border <- props[! grepl("border", names(props))]
+  props_no_border <- props[!grepl("border", names(props))]
   hx_set <- do.call("set_cell_properties", props_no_border)
   if ("left_border" %in% names(props)) {
     hx_set <- set_left_border(hx_set, props$left_border)
@@ -130,8 +131,10 @@ test_that("Some random outputs compile", {
     hx_set <- add_props(hx_raw, variations[sr, ])
     docxo <- sprintf("docx-check-%d.docx", sr)
     outfiles[i] <- docxo
-    expect_error(quick_docx(hx_set, file = docxo, open = FALSE), regexp = NA,
-          info = list(index = sr))
+    expect_error(quick_docx(hx_set, file = docxo, open = FALSE),
+      regexp = NA,
+      info = list(index = sr)
+    )
     expect_true(file.exists(docxo), info = list(index = sr))
   }
 
@@ -140,8 +143,10 @@ test_that("Some random outputs compile", {
     hx_set <- add_props(hx_raw, variations[sr, ])
     pptxo <- sprintf("pptx-check-%d.pptx", sr)
     outfiles[i] <- pptxo
-    expect_error(quick_pptx(hx_set, file = pptxo, open = FALSE), regexp = NA,
-      info = list(index = sr))
+    expect_error(quick_pptx(hx_set, file = pptxo, open = FALSE),
+      regexp = NA,
+      info = list(index = sr)
+    )
     expect_true(file.exists(pptxo), info = list(index = sr))
   }
 })
@@ -155,18 +160,24 @@ test_that("Some random HTML outputs are validated by W3C", {
   # here we do randomize
   for (i in sample(nrow(variations), 10)) {
     hx_set <- add_props(hx_raw, variations[i, ])
-    webpage <- paste0("<!DOCTYPE html><html lang=\"en\">",
+    webpage <- paste0(
+      "<!DOCTYPE html><html lang=\"en\">",
       "<head><meta charset=\"utf-8\"><title>huxtable table validation</title></head>",
-      "<body>\n", to_html(hx_set), "\n</body></html>")
-    response <- httr::POST("http://validator.w3.org/nu/?out=json", body = webpage,
-          httr::content_type("text/html"))
+      "<body>\n", to_html(hx_set), "\n</body></html>"
+    )
+    response <- httr::POST("http://validator.w3.org/nu/?out=json",
+      body = webpage,
+      httr::content_type("text/html")
+    )
     if (httr::status_code(response) != 200) {
-      skip(sprintf("W3C validator returned %s",
-        httr::http_status(response)$message))
+      skip(sprintf(
+        "W3C validator returned %s",
+        httr::http_status(response)$message
+      ))
     }
     response <- httr::content(response, "parsed")
-    errors   <- Filter(function (x) x$type == "error", response$messages)
-    warnings <- Filter(function (x) x$type == "warnings", response$messages)
+    errors <- Filter(function(x) x$type == "error", response$messages)
+    warnings <- Filter(function(x) x$type == "warnings", response$messages)
     valid <- length(errors) == 0
     expect_true(valid, info = list(index = i, errors = errors, warnings = warnings))
   }


### PR DESCRIPTION
## Summary
- Remove quick_pdf example that caused styler parse errors
- Style themes.R using scripts/style.R
- Exclude vignettes and scripts from styling script
- Style all tests under tests/testthat

## Testing
- `R -q -e 'devtools::test(filter = "quick-output|markdown")'` *(fails: LaTeX packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_689499b9eef88330883bd2cd2af4917b