### PR TITLE
Respect valign in Typst export

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 ## Other changes
 
 * Added Typst export via `to_typst()` and `print_typst()`.
+* Typst export now respects vertical alignment via `valign()`.
 
 # huxtable 5.6.0
 

--- a/R/typst.R
+++ b/R/typst.R
@@ -105,7 +105,11 @@ typst_cell_options <- function(ht, i, j, rs, cs, al, row_h) {
   opts <- c()
   if (rs > 1) opts <- c(opts, sprintf("rowspan: %d", rs))
   if (cs > 1) opts <- c(opts, sprintf("colspan: %d", cs))
-  if (!is.na(al)) opts <- c(opts, sprintf("align: %s", al))
+
+  va <- c(top = "top", middle = "center", bottom = "bottom")[valign(ht)[i, j]]
+  if (!is.na(al) || !is.na(va)) {
+    opts <- c(opts, sprintf("align: (%s, %s)", al, va))
+  }
 
   if (!is.na(row_h)) {
     rh <- row_h

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -7,8 +7,8 @@ test_that("to_typst basic table structure", {
     "#table(\n",
     "  columns: (auto, auto)\n",
     ")[\n",
-    "  cell(align: right)[1] cell(align: right)[3]\n",
-    "  cell(align: right)[2] cell(align: right)[4]\n",
+    "  cell(align: (right, top))[1] cell(align: (right, top))[3]\n",
+    "  cell(align: (right, top))[2] cell(align: (right, top))[4]\n",
     "]\n"
   )
   expect_identical(res, expected)
@@ -38,10 +38,21 @@ test_that("to_typst maps properties", {
   expect_match(res, "height: 25\\.000%")
   expect_match(res, "colspan: 2")
   expect_match(res, "rowspan: 2")
-  expect_match(res, "align: right")
+  expect_match(res, "align: (right, top)", fixed = TRUE)
   expect_match(res, "fill: rgb")
   expect_match(res, "stroke: \\(top: 1pt \\+ solid \\+ rgb")
   expect_match(res, "text\\(weight: \"bold\", style: \"italic\", size: 12pt, family: \"Courier\"\\)\\[1\\]")
+})
+
+test_that("to_typst handles vertical alignment", {
+  ht <- hux(a = 1:2, b = 3:4, add_colnames = FALSE)
+  valign(ht)[1, 1] <- "middle"
+  valign(ht)[2, 2] <- "bottom"
+
+  res <- to_typst(ht)
+
+  expect_match(res, "cell(align: (right, center))[1]", fixed = TRUE)
+  expect_match(res, "cell(align: (right, bottom))[4]", fixed = TRUE)
 })
 
 test_that("print_typst outputs to stdout", {


### PR DESCRIPTION
## Summary
- Include vertical alignment in Typst cell options and emit `align: (x, y)`
- Test Typst export for top, middle, and bottom vertical alignment
- Note Typst vertical alignment support in NEWS

## Testing
- `devtools::test(filter = "typst", stop_on_failure = TRUE)`

------
https://chatgpt.com/codex/tasks/task_e_6894a757438c8330bdb2ad4ad0a9d97d