### PR TITLE
Wrap Typst header rows in table.header

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 ## Other changes
 
 * Added Typst export via `to_typst()` and `print_typst()`.
+* `to_typst()` now wraps header rows and columns in `table.header` so they repeat.
 
 # huxtable 5.6.0
 

--- a/R/typst.R
+++ b/R/typst.R
@@ -60,7 +60,38 @@ to_typst <- function(ht, ...) {
   }
 
   row_strings <- apply(cells, 1, function(x) paste(x[x != ""], collapse = " "))
-  result <- paste0(table_start, paste0("  ", row_strings, collapse = "\n"), "\n]\n")
+
+  hr <- header_rows(ht)
+  hc <- header_cols(ht)
+
+  header_block <- ""
+  if (any(hr)) {
+    header_rows_strings <- row_strings[hr]
+    header_block <- paste0(
+      "  table.header[\n",
+      paste0("    ", header_rows_strings, collapse = "\n"),
+      "\n  ]\n"
+    )
+    row_strings <- row_strings[!hr]
+  }
+
+  header_cols_block <- ""
+  if (any(hc)) {
+    col_strings <- apply(cells[, hc, drop = FALSE], 1, function(x) paste(x[x != ""], collapse = " "))
+    header_cols_block <- paste0(
+      "  table.header(columns: (", paste(hc, collapse = ", "), "))[\n",
+      paste0("    ", col_strings, collapse = "\n"),
+      "\n  ]\n"
+    )
+  }
+
+  result <- paste0(
+    table_start,
+    header_block,
+    header_cols_block,
+    paste0("  ", row_strings, collapse = "\n"),
+    "\n]\n"
+  )
   result
 }
 

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -19,6 +19,7 @@ object. AFAIK nobody has ever done this; if I’m wrong, please tell me.
 \subsection{Other changes}{
 \itemize{
 \item Added Typst export via \code{to_typst()} and \code{print_typst()}.
+\item \code{to_typst()} now wraps header rows and columns in \code{table.header} so they repeat.
 }
 }
 }

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -14,6 +14,23 @@ test_that("to_typst basic table structure", {
   expect_identical(res, expected)
 })
 
+test_that("header rows rendered separately", {
+  ht <- hux(a = 1:2, b = 3:4, add_colnames = FALSE)
+  header_rows(ht) <- c(TRUE, FALSE)
+  res <- to_typst(ht)
+  expected <- paste0(
+    "#table(\n",
+    "  columns: (auto, auto)\n",
+    ")[\n",
+    "  table.header[\n",
+    "    cell(align: right)[1] cell(align: right)[3]\n",
+    "  ]\n",
+    "  cell(align: right)[2] cell(align: right)[4]\n",
+    "]\n"
+  )
+  expect_identical(res, expected)
+})
+
 test_that("to_typst maps properties", {
   ht <- hux(a = 1:3, b = 4:6, c = 7:9, add_colnames = FALSE)
   caption(ht) <- "A cap"


### PR DESCRIPTION
## Summary
- ensure `to_typst()` wraps designated header rows and columns in `table.header`
- test that header rows are emitted separately from body rows
- document Typst header behavior in NEWS

## Testing
- `Rscript -e 'devtools::test(filter = "typst")'`


------
https://chatgpt.com/codex/tasks/task_e_6894a80f0a64833080937c377168aacd