### PR TITLE
Prevent Typst cell line breaks when wrap disabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 ## Other changes
 
 * Added Typst export via `to_typst()` and `print_typst()`.
+* `wrap(ht) <- FALSE` now prevents Typst cells from breaking across lines.
 
 # huxtable 5.6.0
 

--- a/R/typst.R
+++ b/R/typst.R
@@ -161,8 +161,14 @@ typst_cell_text <- function(ht, i, j, cell_text) {
   if (!is.na(f <- font(ht)[i, j])) text_opts <- c(text_opts, sprintf("family: \"%s\"", f))
 
   if (length(text_opts) > 0) {
-    sprintf("#text(%s)[%s]", paste(text_opts, collapse = ", "), cell_text)
+    text <- sprintf("#text(%s)[%s]", paste(text_opts, collapse = ", "), cell_text)
   } else {
-    cell_text
+    text <- cell_text
   }
+
+  if (!wrap(ht)[i, j]) {
+    text <- sprintf("#box(breakable: false)[%s]", text)
+  }
+
+  text
 }

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -19,6 +19,8 @@ object. AFAIK nobody has ever done this; if I’m wrong, please tell me.
 \subsection{Other changes}{
 \itemize{
 \item Added Typst export via \code{to_typst()} and \code{print_typst()}.
+\item \code{wrap(ht) <- FALSE} now prevents Typst cells from breaking across
+lines.
 }
 }
 }

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -48,3 +48,14 @@ test_that("print_typst outputs to stdout", {
   ht <- hux(a = 1)
   expect_output(print_typst(ht), trimws(to_typst(ht), which = "right"), fixed = TRUE)
 })
+
+test_that("to_typst respects wrap", {
+  long <- strrep("a", 100)
+  ht <- hux(a = long, add_colnames = FALSE)
+  res_wrap <- to_typst(ht)
+  expect_false(grepl("box\\(breakable: false\\)", res_wrap))
+
+  wrap(ht) <- FALSE
+  res_nowrap <- to_typst(ht)
+  expect_match(res_nowrap, paste0("box\\(breakable: false\\)\\[", long, "\\]"))
+})


### PR DESCRIPTION
## Summary
- Avoid breaking Typst cell text when `wrap(ht)` is FALSE by wrapping output in `box(breakable: false)`.
- Document the new behavior and verify via regression tests for long strings.

## Testing
- `devtools::test(filter = "typst")`


------
https://chatgpt.com/codex/tasks/task_e_6894a7f71d0083308b348cd6dadb9ba3