### PR TITLE
Handle cell rotation in Typst export

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 ## Other changes
 
 * Added Typst export via `to_typst()` and `print_typst()`.
+* Typst export now respects cell rotation.
 
 # huxtable 5.6.0
 

--- a/R/typst.R
+++ b/R/typst.R
@@ -161,8 +161,17 @@ typst_cell_text <- function(ht, i, j, cell_text) {
   if (!is.na(f <- font(ht)[i, j])) text_opts <- c(text_opts, sprintf("family: \"%s\"", f))
 
   if (length(text_opts) > 0) {
-    sprintf("#text(%s)[%s]", paste(text_opts, collapse = ", "), cell_text)
-  } else {
-    cell_text
+    cell_text <- sprintf("#text(%s)[%s]", paste(text_opts, collapse = ", "), cell_text)
   }
+
+  rot <- rotation(ht)[i, j]
+  if (!is.na(rot)) {
+    rot <- rot %% 360
+    if (rot != 0) {
+      reflow <- if (rot %% 180 != 0) ", reflow: true" else ""
+      cell_text <- sprintf("#rotate(%.4gdeg%s)[%s]", rot, reflow, cell_text)
+    }
+  }
+
+  cell_text
 }

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -19,6 +19,7 @@ object. AFAIK nobody has ever done this; if I’m wrong, please tell me.
 \subsection{Other changes}{
 \itemize{
 \item Added Typst export via \code{to_typst()} and \code{print_typst()}.
+\item Typst export now respects cell rotation.
 }
 }
 }

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -44,6 +44,20 @@ test_that("to_typst maps properties", {
   expect_match(res, "text\\(weight: \"bold\", style: \"italic\", size: 12pt, family: \"Courier\"\\)\\[1\\]")
 })
 
+test_that("to_typst rotates 90 degrees", {
+  ht <- hux("a", add_colnames = FALSE)
+  rotation(ht)[1, 1] <- 90
+  res <- to_typst(ht)
+  expect_match(res, "#rotate\\(90deg, reflow: true\\)\\[a\\]")
+})
+
+test_that("to_typst rotates 270 degrees", {
+  ht <- hux("a", add_colnames = FALSE)
+  rotation(ht)[1, 1] <- 270
+  res <- to_typst(ht)
+  expect_match(res, "#rotate\\(270deg, reflow: true\\)\\[a\\]")
+})
+
 test_that("print_typst outputs to stdout", {
   ht <- hux(a = 1)
   expect_output(print_typst(ht), trimws(to_typst(ht), which = "right"), fixed = TRUE)


### PR DESCRIPTION
## Summary
- Wrap Typst cell contents in a rotate call when the `rotation` property is set, using `reflow` for vertical text
- Test 90° and 270° rotations in Typst export
- Note Typst rotation support in NEWS

## Testing
- `R -q -e 'devtools::test(filter = "typst")'`


------
https://chatgpt.com/codex/tasks/task_e_6894becfa194833082c953b2f947e3b3