### PR TITLE
Use CSS classes for HTML output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 ## Other changes
 
 * Added Typst export via `to_typst()` and `print_typst()`.
+* HTML output now uses CSS classes with a shared `<style>` block instead of
+  long inline styles.
 
 # huxtable 5.6.0
 

--- a/R/html.R
+++ b/R/html.R
@@ -2,12 +2,13 @@
 #'
 #' @rdname to_html
 #'
-print_html <- function(ht, ...) cat(to_html(ht, ...))
+print_html <- function(ht, ...) cat(huxtable_html_css(), to_html(ht, ...))
 
 
 #' Create HTML representing a huxtable
 #'
-#' These functions print or return an HTML table.
+#' These functions print or return an HTML table. `print_html` also prepends a
+#' `<style>` block defining basic CSS classes.
 #'
 #' @param ht A huxtable.
 #' @param ... Arguments passed to methods. Not currently used.
@@ -28,9 +29,14 @@ print_html <- function(ht, ...) cat(to_html(ht, ...))
 #' @return `print_notebook` prints HTML output suitable for use in an
 #' RStudio interactive notebook.
 print_notebook <- function(ht, ...) {
-  print(rmarkdown::html_notebook_output_html(to_html(ht)))
+  html <- paste0(huxtable_html_css(), to_html(ht))
+  print(rmarkdown::html_notebook_output_html(html))
 }
 
+
+huxtable_html_css <- function() {
+  "<style>\n.huxtable {\n  border-collapse: collapse;\n  border: 0px;\n  margin-bottom: 2em;\n  margin-top: 2em;\n}\n.huxtable-cell {\n  vertical-align: top;\n  text-align: left;\n  white-space: normal;\n  border-style: solid;\n  border-width: 0pt;\n  padding: 6pt;\n  font-weight: normal;\n}\n.huxtable-header {\n  font-weight: bold;\n}\n</style>\n"
+}
 
 #' @export
 #' @rdname to_html
@@ -58,7 +64,7 @@ build_table_style <- function(ht) {
     ""
   } else {
     if (is.numeric(width)) width <- paste0(width * 100, "%")
-    paste0("width: ", width)
+    sprintf("width: %s;", width)
   }
 
   margin_string <- switch(position(ht),
@@ -92,14 +98,14 @@ build_table_style <- function(ht) {
   } else {
     "data-quarto-disable-processing=\"true\" "
   }
+  style <- paste(width_string, margin_string, height_string, float_string)
+  style <- trimws(style)
+  style_attr <- if (nzchar(style)) sprintf(' style="%s"', style) else ""
   table_start <- sprintf(
-    paste0(
-      '<table class="huxtable" %s',
-      'style="border-collapse: collapse; border: 0px; ',
-      'margin-bottom: 2em; margin-top: 2em; %s; %s %s %s"%s>\n'
-    ),
+    '<table class="huxtable" %s%s%s>\n',
     quarto_attribute,
-    width_string, margin_string, height_string, float_string, id_string
+    style_attr,
+    id_string
   )
 
   if (!is.na(cap <- make_caption(ht, lab, "html"))) {
@@ -155,41 +161,62 @@ build_cell_html <- function(ht) {
   colspan <- blank_where(sprintf(' colspan="%s"', colspan), colspan == 1)
 
   valign <- sprintf("vertical-align: %s;", valign(ht))
-  align <- sprintf(" text-align: %s;", real_align(ht))
-  wrap <- sprintf(" white-space: %s;", ifelse(wrap(ht), "normal", "nowrap"))
+  valign <- blank_where(valign, valign(ht) == "top")
+  align <- sprintf("text-align: %s;", real_align(ht))
+  align <- blank_where(align, real_align(ht) == "left")
+  wrap <- ifelse(wrap(ht), "", "white-space: nowrap;")
 
   border_css <- compute_border_css(ht)
+  border_css <- sub("^ ", "", border_css)
+  border_css <- blank_where(
+    border_css,
+    border_css ==
+      "border-style: solid solid solid solid; border-width: 0pt 0pt 0pt 0pt;"
+  )
 
   add_pts <- function(x) if (is.numeric(x)) sprintf("%.4gpt", x) else x
   padding <- sprintf(
-    " padding: %s %s %s %s;",
+    "padding: %s %s %s %s;",
     add_pts(top_padding(ht)),
     add_pts(right_padding(ht)),
     add_pts(bottom_padding(ht)),
     add_pts(left_padding(ht))
   )
+  padding <- blank_where(padding, padding == "padding: 6pt 6pt 6pt 6pt;")
 
   bg_color <- background_color(ht)
   bg_color <- format_color(bg_color)
-  bg_color <- sprintf(" background-color: rgb(%s);", bg_color)
+  bg_color <- sprintf("background-color: rgb(%s);", bg_color)
   bg_color <- blank_where(bg_color, is.na(background_color(ht)))
 
-  bold <- ifelse(bold(ht), " font-weight: bold;", " font-weight: normal;")
-  italic <- ifelse(italic(ht), " font-style: italic;", "")
+  italic <- ifelse(italic(ht), "font-style: italic;", "")
 
-  font <- sprintf(" font-family: %s;", font(ht))
+  font <- sprintf("font-family: %s;", font(ht))
   font <- blank_where(font, is.na(font(ht)))
-  font_size <- sprintf(" font-size: %.4gpt;", font_size(ht))
+  font_size <- sprintf("font-size: %.4gpt;", font_size(ht))
   font_size <- blank_where(font_size, is.na(font_size(ht)))
 
-  style <- paste0(
-    "style=\"", valign, align, wrap, border_css,
-    padding, bg_color, bold, italic, font, font_size, "\""
+  is_header <- matrix(FALSE, nrow(ht), ncol(ht))
+  is_header[header_rows(ht), ] <- TRUE
+  is_header[, header_cols(ht)] <- TRUE
+  bold_inline <- ifelse(
+    bold(ht) != is_header,
+    ifelse(bold(ht), "font-weight: bold;", "font-weight: normal;"),
+    ""
   )
+
+  style <- trimws(paste(
+    valign, align, wrap, border_css,
+    padding, bg_color, bold_inline, italic, font, font_size
+  ))
+  style <- ifelse(style == "", "", paste0(' style="', style, '"'))
+
   th_td <- matrix("td", nrow(ht), ncol(ht))
   th_td[header_rows(ht), ] <- "th"
   th_td[, header_cols(ht)] <- "th"
-  cell_start <- sprintf("<%s%s%s %s>", th_td, rowspan, colspan, style)
+  cell_class <- matrix('class="huxtable-cell"', nrow(ht), ncol(ht))
+  cell_class[is_header] <- 'class="huxtable-cell huxtable-header"'
+  cell_start <- sprintf("<%s %s%s%s%s>", th_td, cell_class, rowspan, colspan, style)
   cell_end <- sprintf("</%s>", th_td)
   contents <- clean_contents(ht, output_type = "html")
 

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -19,6 +19,8 @@ object. AFAIK nobody has ever done this; if I’m wrong, please tell me.
 \subsection{Other changes}{
 \itemize{
 \item Added Typst export via \code{to_typst()} and \code{print_typst()}.
+\item HTML output now uses CSS classes with a shared \verb{<style>} block instead
+of long inline styles.
 }
 }
 }

--- a/man/to_html.Rd
+++ b/man/to_html.Rd
@@ -24,7 +24,8 @@ to_html(ht, ...)
 RStudio interactive notebook.
 }
 \description{
-These functions print or return an HTML table.
+These functions print or return an HTML table. \code{print_html} also prepends a
+\verb{<style>} block defining basic CSS classes.
 }
 \examples{
 ht <- hux(a = 1:3, b = letters[1:3])
@@ -35,6 +36,7 @@ Other printing functions:
 \code{\link{print_latex}()},
 \code{\link{print_md}()},
 \code{\link{print_rtf}()},
-\code{\link{print_screen}()}
+\code{\link{print_screen}()},
+\code{\link{print_typst}()}
 }
 \concept{printing functions}


### PR DESCRIPTION
## Summary
- Add `huxtable_html_css()` with `.huxtable`, `.huxtable-cell`, and `.huxtable-header` classes.
- Replace repeated inline styles with class attributes in `to_html()` helpers.
- Prepend the CSS block in `print_html()` and `print_notebook` for proper rendering.

## Testing
- `devtools::test(filter='print', stop_on_failure=TRUE)`

------
https://chatgpt.com/codex/tasks/task_e_6894b9739bb083309b24d9867eea2f35