### PR TITLE
Support Typst cell padding via inset

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 ## Other changes
 
 * Added Typst export via `to_typst()` and `print_typst()`.
+* Typst output now respects cell padding through the `inset` argument.
 
 # huxtable 5.6.0
 

--- a/R/typst.R
+++ b/R/typst.R
@@ -118,6 +118,22 @@ typst_cell_options <- function(ht, i, j, rs, cs, al, row_h) {
     opts <- c(opts, sprintf("fill: rgb(%s)", format_color(bg)))
   }
 
+  pads <- c(
+    top    = top_padding(ht)[i, j],
+    right  = right_padding(ht)[i, j],
+    bottom = bottom_padding(ht)[i, j],
+    left   = left_padding(ht)[i, j]
+  )
+  if (!all(is.na(pads))) {
+    if (length(unique(pads)) == 1) {
+      opts <- c(opts, sprintf("inset: %.4gpt", pads[[1]]))
+    } else {
+      pad_parts <- sprintf("%s: %.4gpt", names(pads), pads)
+      pad_parts <- pad_parts[!is.na(pads)]
+      opts <- c(opts, sprintf("inset: (%s)", paste(pad_parts, collapse = ", ")))
+    }
+  }
+
   stroke <- typst_stroke(ht, i, j)
   if (length(stroke)) opts <- c(opts, stroke)
 

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -19,6 +19,7 @@ object. AFAIK nobody has ever done this; if I’m wrong, please tell me.
 \subsection{Other changes}{
 \itemize{
 \item Added Typst export via \code{to_typst()} and \code{print_typst()}.
+\item Typst output now respects cell padding through the \code{inset} argument.
 }
 }
 }

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -7,8 +7,8 @@ test_that("to_typst basic table structure", {
     "#table(\n",
     "  columns: (auto, auto)\n",
     ")[\n",
-    "  cell(align: right)[1] cell(align: right)[3]\n",
-    "  cell(align: right)[2] cell(align: right)[4]\n",
+    "  cell(align: right, inset: 6pt)[1] cell(align: right, inset: 6pt)[3]\n",
+    "  cell(align: right, inset: 6pt)[2] cell(align: right, inset: 6pt)[4]\n",
     "]\n"
   )
   expect_identical(res, expected)
@@ -30,6 +30,11 @@ test_that("to_typst maps properties", {
   font_size(ht)[1, 1] <- 12
   font(ht)[1, 1] <- "Courier"
 
+  left_padding(ht)[1, 3] <- 1
+  right_padding(ht)[1, 3] <- 2
+  top_padding(ht)[1, 3] <- 3
+  bottom_padding(ht)[1, 3] <- 4
+
   res <- to_typst(ht)
 
   expect_match(res, "caption: \\[A cap\\]")
@@ -42,6 +47,7 @@ test_that("to_typst maps properties", {
   expect_match(res, "fill: rgb")
   expect_match(res, "stroke: \\(top: 1pt \\+ solid \\+ rgb")
   expect_match(res, "text\\(weight: \"bold\", style: \"italic\", size: 12pt, family: \"Courier\"\\)\\[1\\]")
+  expect_match(res, "inset: \\(top: 3pt, right: 2pt, bottom: 4pt, left: 1pt\\)")
 })
 
 test_that("print_typst outputs to stdout", {


### PR DESCRIPTION
## Summary
- Map huxtable cell padding to Typst's `inset` option
- Test Typst output with asymmetric padding values
- Document Typst padding support in NEWS and rebuild documentation

## Testing
- `Rscript -e "devtools::test(filter='typst')"`
- `Rscript -e "devtools::document()"`


------
https://chatgpt.com/codex/tasks/task_e_6894be8295408330b72edefe21d90d08