### PR TITLE
Fix Typst alignment syntax

### DIFF
--- a/R/typst.R
+++ b/R/typst.R
@@ -37,7 +37,7 @@ to_typst <- function(ht, ...) {
   align_h <- real_align(ht)
   align_v <- valign(ht)
   align_v[] <- c(top = "top", middle = "horizon", bottom = "bottom")[align_v]
-  align <- ifelse(is.na(align_v), align_h, paste0("(", align_h, ", ", align_v, ")"))
+  align <- ifelse(is.na(align_v), align_h, paste0("(", align_h, " + ", align_v, ")"))
 
   col_w <- col_width(ht)
   if (is.numeric(col_w)) {

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -7,8 +7,8 @@ test_that("to_typst basic table structure", {
     "#table(\n",
     "  columns: (auto, auto)\n",
     ")[\n",
-    "  cell(align: (right, top))[1] cell(align: (right, top))[3]\n",
-    "  cell(align: (right, top))[2] cell(align: (right, top))[4]\n",
+    "  cell(align: (right + top))[1] cell(align: (right + top))[3]\n",
+    "  cell(align: (right + top))[2] cell(align: (right + top))[4]\n",
     "]\n"
   )
   expect_identical(res, expected)
@@ -23,9 +23,9 @@ test_that("header rows rendered separately", {
     "  columns: (auto, auto)\n",
     ")[\n",
     "  table.header[\n",
-    "    cell(align: (right, top))[1] cell(align: (right, top))[3]\n",
+    "    cell(align: (right + top))[1] cell(align: (right + top))[3]\n",
     "  ]\n",
-    "  cell(align: (right, top))[2] cell(align: (right, top))[4]\n",
+    "  cell(align: (right + top))[2] cell(align: (right + top))[4]\n",
     "]\n"
   )
   expect_identical(res, expected)
@@ -56,7 +56,7 @@ test_that("to_typst maps properties", {
   expect_match(res, "height: 25\\.000%")
   expect_match(res, "colspan: 2")
   expect_match(res, "rowspan: 2")
-  expect_match(res, "align: (right, top)", fixed = TRUE)
+  expect_match(res, "align: (right + top)", fixed = TRUE)
   expect_match(res, "fill: rgb")
   expect_match(res, "stroke: \\(top: 1pt \\+ solid \\+ rgb")
   expect_match(res, "text\\(weight: \"bold\", style: \"italic\", size: 12pt, family: \"Courier\", fill: rgb")
@@ -69,8 +69,8 @@ test_that("to_typst handles vertical alignment", {
 
   res <- to_typst(ht)
 
-  expect_match(res, "cell(align: (right, horizon))[1]", fixed = TRUE)
-  expect_match(res, "cell(align: (right, bottom))[4]", fixed = TRUE)
+  expect_match(res, "cell(align: (right + horizon))[1]", fixed = TRUE)
+  expect_match(res, "cell(align: (right + bottom))[4]", fixed = TRUE)
 })
 
 test_that("print_typst outputs to stdout", {
@@ -95,7 +95,7 @@ test_that("to_typst handles table alignment", {
   expect_match(to_typst(ht), "align: right")
 })
 
-  test_that("to_typst respects wrap", {
+test_that("to_typst respects wrap", {
   long <- strrep("a", 100)
   ht <- hux(a = long, add_colnames = FALSE)
   res_wrap <- to_typst(ht)


### PR DESCRIPTION
## Summary
- Use `+` for Typst cell alignment to match 2-D syntax
- Expect `horizon` for middle vertical alignment in Typst tests

## Testing
- `devtools::test(filter = "typst")`


------
https://chatgpt.com/codex/tasks/task_e_68958c0a7b2883309c896235eb948262