### PR TITLE
Add Quarto Typst end-to-end test

### DIFF
--- a/tests/testthat/quarto-typst.qmd
+++ b/tests/testthat/quarto-typst.qmd
@@ -1,0 +1,9 @@
+---
+title: "Quarto Typst Test"
+format: typst
+---
+
+```{r}
+library(huxtable)
+hux(a = 1:2, b = 3:4)
+```


### PR DESCRIPTION
## Summary
- inline Quarto/Typst validation helper in end-to-end tests
- ensure typst source lives beside QMD and validate via CLI
- clean up temporary Typst artifacts after tests

## Testing
- `PATH=/workspace:$PATH R --vanilla <<'EOF'
...testthat...
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 1 ]
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68953097d3848330b514df9a7871f15a