### PR TITLE
refactor: replace roxygen templates for table properties

### DIFF
--- a/R/doc-helpers.R
+++ b/R/doc-helpers.R
@@ -7,7 +7,8 @@
 #' @noRd
 rd_default <- function(prop) {
   default <- huxtable_env$huxtable_default_attrs[[prop]]
-  paste0("Set to `NA` to reset to the default, which is ", default, ".")
+  default <- deparse(default)
+  paste0("Set to `NA` to reset to the default, which is `", default, "`.")
 }
 
 # Shared documentation for huxtable property functions:
@@ -16,6 +17,9 @@ rd_default <- function(prop) {
 #' @param row A row specifier. See [rowspecs] for details.
 #' @param col An optional column specifier.
 #' @param fn A mapping function. See [mapping-functions] for details.
-#'
+#' @return
+#'   `property()` returns the property value(s).
+#'   `set_property()` and `map_property()` return the modified huxtable.
+#' 
 #' @name hux_prop_params
 NULL

--- a/R/properties-table.R
+++ b/R/properties-table.R
@@ -3,25 +3,27 @@
 #' Table position may be "left", "right" or "center". If you want text to
 #' wrap around the table, use "wrapleft" or "wrapright".
 #'
-#' @template getset-table
-#' @templateVar attr_name position
-#' @templateVar attr_desc Table position
-#' @templateVar value_param_desc
-#' String. "left", "center", "right", "wrapleft" or "wrapright".
+#' @inherit hux_prop_params params return
+#' @param value String. "left", "center", "right", "wrapleft" or "wrapright". `r rd_default("position")`
 #' @details
 #' `"wrapleft"` and `"wrapright"` position the table to the left or right, and allow text to
 #' wrap around the table.
 #'
-#' @template getset-example
-#' @templateVar attr_val "right"
 #' @examples
 #'
 #' set_position(jams, "left")
 #' set_position(jams, "right")
 #' set_position(jams, "center")
 #'
+#' @name position
 NULL
+
+#' @rdname position
+#' @export
 position <- function(ht) prop_get(ht, "position")
+
+#' @rdname position
+#' @export
 `position<-` <- function(ht, value) {
   prop_replace(ht, value, "position",
     check_values = c("left", "center", "centre", "right", "wrapleft", "wrapright"),
@@ -30,6 +32,9 @@ position <- function(ht) prop_get(ht, "position")
     })
   )
 }
+
+#' @rdname position
+#' @export
 set_position <- function(ht, value) {
   prop_set_table(ht, value, "position",
     check_values = c("left", "center", "centre", "right", "wrapleft", "wrapright"),
@@ -45,14 +50,8 @@ set_position <- function(ht, value) {
 #' If `caption_pos` is "top" or "bottom", then the horizontal position ("left",
 #' "center" or "right") will be determined by the huxtable"s [position()].
 #'
-#' @template getset-table
-#' @templateVar attr_name caption_pos
-#' @templateVar attr_desc Caption position
-#' @templateVar value_param_desc
-#' String: "top", "bottom", "topleft", "topcenter", "topright", "bottomleft", "bottomcenter" or "bottomright".
-#'
-#' @template getset-example
-#' @templateVar attr_val "topleft"
+#' @inherit hux_prop_params params return
+#' @param value String: "top", "bottom", "topleft", "topcenter", "topright", "bottomleft", "bottomcenter" or "bottomright". `r rd_default("caption_pos")`
 #'
 #' @family caption properties
 #' @examples
@@ -61,8 +60,15 @@ set_position <- function(ht, value) {
 #' jams
 #' set_caption_pos(jams, "bottom")
 #'
+#' @name caption_pos
 NULL
+
+#' @rdname caption_pos
+#' @export
 caption_pos <- function(ht) prop_get(ht, "caption_pos")
+
+#' @rdname caption_pos
+#' @export
 `caption_pos<-` <- function(ht, value) {
   prop_replace(ht, value, "caption_pos",
     check_values = c(
@@ -75,6 +81,9 @@ caption_pos <- function(ht) prop_get(ht, "caption_pos")
     })
   )
 }
+
+#' @rdname caption_pos
+#' @export
 set_caption_pos <- function(ht, value) {
   prop_set_table(ht, value, "caption_pos",
     check_values = c(
@@ -97,19 +106,29 @@ set_caption_pos <- function(ht, value) {
 #' LaTeX or CSS dimension. The default, `NA`, makes the caption the same width
 #' as the table.
 #'
-#' @template getset-table
-#' @templateVar attr_name caption_width
-#' @templateVar value_param_desc Number or string.
+#' @inherit hux_prop_params params return
+#' @param value Number or string. `r rd_default("caption_width")`
 #'
 #' @family caption properties
 #'
-#' @template getset-example
-#' @templateVar attr_val 0.5
+#' @examples
+#' set_caption_width(jams, 0.5)
+#'
+#' @name caption_width
 NULL
+
+#' @rdname caption_width
+#' @export
 caption_width <- function(ht) prop_get(ht, "caption_width")
+
+#' @rdname caption_width
+#' @export
 `caption_width<-` <- function(ht, value) {
   prop_replace(ht, value, "caption_width", check_fun = is_numeric_or_character)
 }
+
+#' @rdname caption_width
+#' @export
 set_caption_width <- function(ht, value) {
   prop_set_table(ht, value, "caption_width", check_fun = is_numeric_or_character)
 }
@@ -122,18 +141,28 @@ set_caption_width <- function(ht, value) {
 #' f the surrounding block width (HTML) or text width (LaTeX). A character width
 #' must be a valid CSS or LaTeX dimension.
 #'
-#' @template getset-table
-#' @templateVar attr_name width
-#' @templateVar value_param_desc A number or string.
+#' @inherit hux_prop_params params return
+#' @param value A number or string. `r rd_default("width")`
 #'
-#' @template getset-example
-#' @templateVar attr_val 0.8
+#' @examples
+#' set_width(jams, 0.8)
+#'
 #' @family table measurements
+#' @name width
 NULL
+
+#' @rdname width
+#' @export
 width <- function(ht) prop_get(ht, "width")
+
+#' @rdname width
+#' @export
 `width<-` <- function(ht, value) {
   prop_replace(ht, value, "width", check_fun = is_numeric_or_character)
 }
+
+#' @rdname width
+#' @export
 set_width <- function(ht, value) {
   prop_set_table(ht, value, "width", check_fun = is_numeric_or_character)
 }
@@ -141,24 +170,34 @@ set_width <- function(ht, value) {
 
 #' Set the table height
 #'
-#' `height()`` sets the height of the entire table, while [row_height()] sets the
+#' `height()` sets the height of the entire table, while [row_height()] sets the
 #' height of individual rows. A numeric height is treated as a proportion of
-#' the containing block (HTML) or `\\textheight` (LaTeX). A character height
+#' the containing block (HTML) or `\textheight` (LaTeX). A character height
 #' must be a valid CSS or LaTeX dimension.
 #'
-#' @template getset-table
-#' @templateVar attr_name height
-#' @templateVar value_param_desc A number or string.
+#' @inherit hux_prop_params params return
+#' @param value A number or string. `r rd_default("height")`
 #'
 #' @family table measurements
 #'
-#' @template getset-example
-#' @templateVar attr_val 0.4
+#' @examples
+#' set_height(jams, 0.4)
+#'
+#' @name height
 NULL
+
+#' @rdname height
+#' @export
 height <- function(ht) prop_get(ht, "height")
+
+#' @rdname height
+#' @export
 `height<-` <- function(ht, value) {
   prop_replace(ht, value, "height", check_fun = is_numeric_or_character)
 }
+
+#' @rdname height
+#' @export
 set_height <- function(ht, value) {
   prop_set_table(ht, value, "height", check_fun = is_numeric_or_character)
 }
@@ -168,9 +207,9 @@ set_height <- function(ht, value) {
 #'
 #' By default, captions are displayed above the table. You can change this
 #' with [caption_pos()].
-#' @template getset-table
-#' @templateVar attr_name caption
-#' @templateVar value_param_desc A string.
+#'
+#' @inherit hux_prop_params params return
+#' @param value A string. `r rd_default("caption")`
 #'
 #' @details
 #' Captions are not escaped. See the example for a workaround.
@@ -185,11 +224,21 @@ set_height <- function(ht, value) {
 #'   type = "latex"
 #' )
 #'
+#' @name caption
 NULL
+
+#' @rdname caption
+#' @export
 caption <- function(ht) prop_get(ht, "caption")
+
+#' @rdname caption
+#' @export
 `caption<-` <- function(ht, value) {
   prop_replace(ht, value, "caption", check_fun = is.string)
 }
+
+#' @rdname caption
+#' @export
 set_caption <- function(ht, value) {
   prop_set_table(ht, value, "caption", check_fun = is.string)
 }
@@ -198,21 +247,32 @@ set_caption <- function(ht, value) {
 #' Set the table's tabular environment in LaTeX
 #'
 #' By default this is either `"tabular"` or `"tabularx"`.
-#' @template getset-table
-#' @templateVar attr_name tabular_environment
-#' @templateVar value_param_desc A string.
+#'
+#' @inherit hux_prop_params params return
+#' @param value A string. `r rd_default("tabular_environment")`
 #'
 #' @details
 #' No features are guaranteed to work if you set this to a non-default
 #' value. Use at your own risk!
 #'
-#' @template getset-example
-#' @templateVar attr_val "longtable"
+#' @examples
+#' set_tabular_environment(jams, "longtable")
+#'
+#' @name tabular_environment
 NULL
+
+#' @rdname tabular_environment
+#' @export
 tabular_environment <- function(ht) prop_get(ht, "tabular_environment")
+
+#' @rdname tabular_environment
+#' @export
 `tabular_environment<-` <- function(ht, value) {
   prop_replace(ht, value, "tabular_environment", check_fun = is.string)
 }
+
+#' @rdname tabular_environment
+#' @export
 set_tabular_environment <- function(ht, value) {
   prop_set_table(ht, value, "tabular_environment", check_fun = is.string)
 }
@@ -221,9 +281,9 @@ set_tabular_environment <- function(ht, value) {
 #' Set the "table" environment in LaTeX
 #'
 #' By default this is `"table"`.
-#' @template getset-table
-#' @templateVar attr_name table_environment
-#' @templateVar value_param_desc A string.
+#'
+#' @inherit hux_prop_params params return
+#' @param value A string. `r rd_default("table_environment")`
 #'
 #' @details
 #' No features are guaranteed to work if you set this to a non-default
@@ -233,13 +293,24 @@ set_tabular_environment <- function(ht, value) {
 #' If [position()] is set to `"wrapleft"` or `"wrapright"`, this
 #' value is overridden.
 #'
-#' @template getset-example
-#' @templateVar attr_val "table*"
+#' @examples
+#' set_table_environment(jams, "table*")
+#'
+#' @name table_environment
 NULL
+
+#' @rdname table_environment
+#' @export
 table_environment <- function(ht) prop_get(ht, "table_environment")
+
+#' @rdname table_environment
+#' @export
 `table_environment<-` <- function(ht, value) {
   prop_replace(ht, value, "table_environment", check_fun = is.string)
 }
+
+#' @rdname table_environment
+#' @export
 set_table_environment <- function(ht, value) {
   prop_set_table(ht, value, "table_environment", check_fun = is.string)
 }
@@ -250,12 +321,9 @@ set_table_environment <- function(ht, value) {
 #' The label is used as the table's label in LaTeX, and as the "id" property
 #' of the table element in HTML.
 #'
-#' @template getset-table
-#' @templateVar attr_name label
-#' @templateVar value_param_desc A string.
+#' @inherit hux_prop_params params return
+#' @param value A string. `r rd_default("label")`
 #'
-#' @template getset-example
-#' @templateVar attr_val "tab:mytable"
 #' @seealso huxtable-options
 #' @details
 #' LaTeX table labels typically start with `"tab:"`.
@@ -270,11 +338,24 @@ set_table_environment <- function(ht, value) {
 #' automatically. To turn off this behaviour, set
 #' `options(huxtable.bookdown = FALSE)`.
 #'
+#' @examples
+#' set_label(jams, "tab:mytable")
+#'
+#' @name label
 NULL
+
+#' @rdname label
+#' @export
 label <- function(ht) prop_get(ht, "label")
+
+#' @rdname label
+#' @export
 `label<-` <- function(ht, value) {
   prop_replace(ht, value, "label", check_fun = is.string)
 }
+
+#' @rdname label
+#' @export
 set_label <- function(ht, value) {
   prop_set_table(ht, value, "label", check_fun = is.string)
 }
@@ -292,17 +373,27 @@ set_label <- function(ht, value) {
 #'
 #' See LaTeX documentation for more details.
 #'
-#' @template getset-table
-#' @templateVar attr_name latex_float
-#' @templateVar value_param_desc A string.
+#' @inherit hux_prop_params params return
+#' @param value A string. `r rd_default("latex_float")`
 #'
-#' @template getset-example
-#' @templateVar attr_val "b"
+#' @examples
+#' set_latex_float(jams, "b")
+#'
+#' @name latex_float
 NULL
+
+#' @rdname latex_float
+#' @export
 latex_float <- function(ht) prop_get(ht, "latex_float")
+
+#' @rdname latex_float
+#' @export
 `latex_float<-` <- function(ht, value) {
   prop_replace(ht, value, "latex_float", check_fun = is.string)
 }
+
+#' @rdname latex_float
+#' @export
 set_latex_float <- function(ht, value) {
   prop_set_table(ht, value, "latex_float", check_fun = is.string)
 }

--- a/man/align.Rd
+++ b/man/align.Rd
@@ -18,7 +18,7 @@ map_align(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A character vector or matrix. Set to \code{NA} to reset to the default, which is left.}
+\item{value}{A character vector or matrix. Set to \code{NA} to reset to the default, which is \code{"left"}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/background_color.Rd
+++ b/man/background_color.Rd
@@ -18,7 +18,7 @@ map_background_color(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A character vector or matrix. Set to \code{NA} to reset to the default, which is NA.}
+\item{value}{A character vector or matrix. Set to \code{NA} to reset to the default, which is \code{NA_character_}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/bold.Rd
+++ b/man/bold.Rd
@@ -30,7 +30,7 @@ map_italic(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A logical vector or matrix. Set to \code{NA} to reset to the default, which is FALSE.}
+\item{value}{A logical vector or matrix. Set to \code{NA} to reset to the default, which is \code{FALSE}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/border-colors.Rd
+++ b/man/border-colors.Rd
@@ -56,7 +56,7 @@ map_bottom_border_color(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A valid R color, e.g. \code{"red"}, \code{"#FF0000"}. Set to \code{NA} to reset to the default, which is NA.}
+\item{value}{A valid R color, e.g. \code{"red"}, \code{"#FF0000"}. Set to \code{NA} to reset to the default, which is \code{NA_character_}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/border-styles.Rd
+++ b/man/border-styles.Rd
@@ -56,7 +56,7 @@ map_bottom_border_style(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{One of \code{"solid"}, \code{"double"}, \code{"dashed"} or \code{"dotted"}. Set to \code{NA} to reset to the default, which is solid.}
+\item{value}{One of \code{"solid"}, \code{"double"}, \code{"dashed"} or \code{"dotted"}. Set to \code{NA} to reset to the default, which is \code{"solid"}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/borders.Rd
+++ b/man/borders.Rd
@@ -56,7 +56,7 @@ map_bottom_border(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A numeric thickness or a \code{\link[=brdr]{brdr()}} object. Set to \code{NA} to reset to the default, which is 0.}
+\item{value}{A numeric thickness or a \code{\link[=brdr]{brdr()}} object. Set to \code{NA} to reset to the default, which is \code{0}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/caption.Rd
+++ b/man/caption.Rd
@@ -7,18 +7,19 @@
 \title{Set the table caption}
 \usage{
 caption(ht)
+
 caption(ht) <- value
+
 set_caption(ht, value)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A string. Set to \code{NA} to reset to the default, which is
-\code{"NA"}.}
+\item{value}{A string. Set to \code{NA} to reset to the default, which is \code{NA_character_}.}
 }
 \value{
-\code{caption()} returns the \code{caption} property.
-\code{set_caption()} returns the modified huxtable.
+\code{property()} returns the property value(s).
+\code{set_property()} and \code{map_property()} return the modified huxtable.
 }
 \description{
 By default, captions are displayed above the table. You can change this

--- a/man/caption_pos.Rd
+++ b/man/caption_pos.Rd
@@ -7,27 +7,25 @@
 \title{Position the table's caption}
 \usage{
 caption_pos(ht)
+
 caption_pos(ht) <- value
+
 set_caption_pos(ht, value)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{String: "top", "bottom", "topleft", "topcenter", "topright", "bottomleft", "bottomcenter" or "bottomright". Set to \code{NA} to reset to the default, which is
-\code{"top"}.}
+\item{value}{String: "top", "bottom", "topleft", "topcenter", "topright", "bottomleft", "bottomcenter" or "bottomright". Set to \code{NA} to reset to the default, which is \code{"top"}.}
 }
 \value{
-\code{caption_pos()} returns the \code{caption_pos} property.
-\code{set_caption_pos()} returns the modified huxtable.
+\code{property()} returns the property value(s).
+\code{set_property()} and \code{map_property()} return the modified huxtable.
 }
 \description{
 If \code{caption_pos} is "top" or "bottom", then the horizontal position ("left",
 "center" or "right") will be determined by the huxtable"s \code{\link[=position]{position()}}.
 }
 \examples{
-
-caption_pos(jams) <-  "topleft"
-caption_pos(jams)
 
 caption(jams) <- "Jam for sale"
 jams

--- a/man/caption_width.Rd
+++ b/man/caption_width.Rd
@@ -7,18 +7,19 @@
 \title{Set the width of the table caption}
 \usage{
 caption_width(ht)
+
 caption_width(ht) <- value
+
 set_caption_width(ht, value)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{Number or string. Set to \code{NA} to reset to the default, which is
-\code{NA}.}
+\item{value}{Number or string. Set to \code{NA} to reset to the default, which is \code{NA_real_}.}
 }
 \value{
-\code{caption_width()} returns the \code{caption_width} property.
-\code{set_caption_width()} returns the modified huxtable.
+\code{property()} returns the property value(s).
+\code{set_property()} and \code{map_property()} return the modified huxtable.
 }
 \description{
 A numeric widths is interpreted as a proportion of text width in LaTeX, or of
@@ -27,9 +28,8 @@ LaTeX or CSS dimension. The default, \code{NA}, makes the caption the same width
 as the table.
 }
 \examples{
+set_caption_width(jams, 0.5)
 
-caption_width(jams) <-  0.5
-caption_width(jams)
 }
 \seealso{
 Other caption properties: 

--- a/man/escape_contents.Rd
+++ b/man/escape_contents.Rd
@@ -18,7 +18,7 @@ map_escape_contents(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A logical vector or matrix. Set to \code{NA} to reset to the default, which is TRUE.}
+\item{value}{A logical vector or matrix. Set to \code{NA} to reset to the default, which is \code{TRUE}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/font.Rd
+++ b/man/font.Rd
@@ -18,7 +18,7 @@ map_font(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A character vector or matrix. Set to \code{NA} to reset to the default, which is NA.}
+\item{value}{A character vector or matrix. Set to \code{NA} to reset to the default, which is \code{NA_character_}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/font_size.Rd
+++ b/man/font_size.Rd
@@ -18,7 +18,7 @@ map_font_size(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A numeric vector. Set to \code{NA} to reset to the default, which is NA.}
+\item{value}{A numeric vector. Set to \code{NA} to reset to the default, which is \code{NA_real_}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/height.Rd
+++ b/man/height.Rd
@@ -7,27 +7,29 @@
 \title{Set the table height}
 \usage{
 height(ht)
+
 height(ht) <- value
+
 set_height(ht, value)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A number or string. Set to \code{NA} to reset to the default, which is
-\code{NA}.}
+\item{value}{A number or string. Set to \code{NA} to reset to the default, which is \code{NA_real_}.}
 }
 \value{
-\code{height()} returns the \code{height} property.
-\code{set_height()} returns the modified huxtable.
+\code{property()} returns the property value(s).
+\code{set_property()} and \code{map_property()} return the modified huxtable.
 }
 \description{
-\verb{height()`` sets the height of the entire table, while [row_height()] sets the height of individual rows. A numeric height is treated as a proportion of the containing block (HTML) or }\\textheight` (LaTeX). A character height
+\code{height()} sets the height of the entire table, while \code{\link[=row_height]{row_height()}} sets the
+height of individual rows. A numeric height is treated as a proportion of
+the containing block (HTML) or \verb{\\textheight} (LaTeX). A character height
 must be a valid CSS or LaTeX dimension.
 }
 \examples{
+set_height(jams, 0.4)
 
-height(jams) <-  0.4
-height(jams)
 }
 \seealso{
 Other table measurements: 

--- a/man/label.Rd
+++ b/man/label.Rd
@@ -7,18 +7,19 @@
 \title{Set a table label for external referencing}
 \usage{
 label(ht)
+
 label(ht) <- value
+
 set_label(ht, value)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A string. Set to \code{NA} to reset to the default, which is
-\code{"NA"}.}
+\item{value}{A string. Set to \code{NA} to reset to the default, which is \code{NA_character_}.}
 }
 \value{
-\code{label()} returns the \code{label} property.
-\code{set_label()} returns the modified huxtable.
+\code{property()} returns the property value(s).
+\code{set_property()} and \code{map_property()} return the modified huxtable.
 }
 \description{
 The label is used as the table's label in LaTeX, and as the "id" property
@@ -38,9 +39,8 @@ automatically. To turn off this behaviour, set
 \code{options(huxtable.bookdown = FALSE)}.
 }
 \examples{
+set_label(jams, "tab:mytable")
 
-label(jams) <-  "tab:mytable"
-label(jams)
 }
 \seealso{
 huxtable-options

--- a/man/latex_float.Rd
+++ b/man/latex_float.Rd
@@ -7,18 +7,19 @@
 \title{Set the position of the table float in LaTeX}
 \usage{
 latex_float(ht)
+
 latex_float(ht) <- value
+
 set_latex_float(ht, value)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A string. Set to \code{NA} to reset to the default, which is
-\code{"ht"}.}
+\item{value}{A string. Set to \code{NA} to reset to the default, which is \code{"ht"}.}
 }
 \value{
-\code{latex_float()} returns the \code{latex_float} property.
-\code{set_latex_float()} returns the modified huxtable.
+\code{property()} returns the property value(s).
+\code{set_property()} and \code{map_property()} return the modified huxtable.
 }
 \description{
 Possible values include:
@@ -35,7 +36,6 @@ Possible values include:
 See LaTeX documentation for more details.
 }
 \examples{
+set_latex_float(jams, "b")
 
-latex_float(jams) <-  "b"
-latex_float(jams)
 }

--- a/man/markdown.Rd
+++ b/man/markdown.Rd
@@ -18,7 +18,7 @@ map_markdown(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A logical vector or matrix. Set to \code{NA} to reset to the default, which is FALSE.}
+\item{value}{A logical vector or matrix. Set to \code{NA} to reset to the default, which is \code{FALSE}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/na_string.Rd
+++ b/man/na_string.Rd
@@ -18,7 +18,7 @@ map_na_string(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A character vector or matrix. Set to \code{NA} to reset to the default, which is .}
+\item{value}{A character vector or matrix. Set to \code{NA} to reset to the default, which is \code{""}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/padding.Rd
+++ b/man/padding.Rd
@@ -55,7 +55,7 @@ map_bottom_padding(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{Numeric: padding width/height in points. Set to \code{NA} to reset to the default, which is 6.}
+\item{value}{Numeric: padding width/height in points. Set to \code{NA} to reset to the default, which is \code{6}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/position.Rd
+++ b/man/position.Rd
@@ -7,18 +7,19 @@
 \title{Set the table's position with respect to surrounding content}
 \usage{
 position(ht)
+
 position(ht) <- value
+
 set_position(ht, value)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{String. "left", "center", "right", "wrapleft" or "wrapright". Set to \code{NA} to reset to the default, which is
-\code{"center"}.}
+\item{value}{String. "left", "center", "right", "wrapleft" or "wrapright". Set to \code{NA} to reset to the default, which is \code{"center"}.}
 }
 \value{
-\code{position()} returns the \code{position} property.
-\code{set_position()} returns the modified huxtable.
+\code{property()} returns the property value(s).
+\code{set_property()} and \code{map_property()} return the modified huxtable.
 }
 \description{
 Table position may be "left", "right" or "center". If you want text to
@@ -29,9 +30,6 @@ wrap around the table, use "wrapleft" or "wrapright".
 wrap around the table.
 }
 \examples{
-
-position(jams) <-  "right"
-position(jams)
 
 set_position(jams, "left")
 set_position(jams, "right")

--- a/man/rotation.Rd
+++ b/man/rotation.Rd
@@ -18,7 +18,7 @@ map_rotation(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A numeric vector or matrix. Set to \code{NA} to reset to the default, which is 0.}
+\item{value}{A numeric vector or matrix. Set to \code{NA} to reset to the default, which is \code{0}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/table_environment.Rd
+++ b/man/table_environment.Rd
@@ -7,18 +7,19 @@
 \title{Set the "table" environment in LaTeX}
 \usage{
 table_environment(ht)
+
 table_environment(ht) <- value
+
 set_table_environment(ht, value)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A string. Set to \code{NA} to reset to the default, which is
-\code{"table"}.}
+\item{value}{A string. Set to \code{NA} to reset to the default, which is \code{"table"}.}
 }
 \value{
-\code{table_environment()} returns the \code{table_environment} property.
-\code{set_table_environment()} returns the modified huxtable.
+\code{property()} returns the property value(s).
+\code{set_property()} and \code{map_property()} return the modified huxtable.
 }
 \description{
 By default this is \code{"table"}.
@@ -32,7 +33,6 @@ If \code{\link[=position]{position()}} is set to \code{"wrapleft"} or \code{"wra
 value is overridden.
 }
 \examples{
+set_table_environment(jams, "table*")
 
-table_environment(jams) <-  "table*"
-table_environment(jams)
 }

--- a/man/tabular_environment.Rd
+++ b/man/tabular_environment.Rd
@@ -7,18 +7,19 @@
 \title{Set the table's tabular environment in LaTeX}
 \usage{
 tabular_environment(ht)
+
 tabular_environment(ht) <- value
+
 set_tabular_environment(ht, value)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A string. Set to \code{NA} to reset to the default, which is
-\code{"NA"}.}
+\item{value}{A string. Set to \code{NA} to reset to the default, which is \code{NA_character_}.}
 }
 \value{
-\code{tabular_environment()} returns the \code{tabular_environment} property.
-\code{set_tabular_environment()} returns the modified huxtable.
+\code{property()} returns the property value(s).
+\code{set_property()} and \code{map_property()} return the modified huxtable.
 }
 \description{
 By default this is either \code{"tabular"} or \code{"tabularx"}.
@@ -28,7 +29,6 @@ No features are guaranteed to work if you set this to a non-default
 value. Use at your own risk!
 }
 \examples{
+set_tabular_environment(jams, "longtable")
 
-tabular_environment(jams) <-  "longtable"
-tabular_environment(jams)
 }

--- a/man/text_color.Rd
+++ b/man/text_color.Rd
@@ -18,7 +18,7 @@ map_text_color(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A character vector or matrix. Set to \code{NA} to reset to the default, which is NA.}
+\item{value}{A character vector or matrix. Set to \code{NA} to reset to the default, which is \code{NA_character_}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/valign.Rd
+++ b/man/valign.Rd
@@ -18,7 +18,7 @@ map_valign(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A character vector or matrix. Set to \code{NA} to reset to the default, which is top.}
+\item{value}{A character vector or matrix. Set to \code{NA} to reset to the default, which is \code{"top"}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 

--- a/man/width.Rd
+++ b/man/width.Rd
@@ -7,18 +7,19 @@
 \title{Set the table width}
 \usage{
 width(ht)
+
 width(ht) <- value
+
 set_width(ht, value)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A number or string. Set to \code{NA} to reset to the default, which is
-\code{NA}.}
+\item{value}{A number or string. Set to \code{NA} to reset to the default, which is \code{NA_real_}.}
 }
 \value{
-\code{width()} returns the \code{width} property.
-\code{set_width()} returns the modified huxtable.
+\code{property()} returns the property value(s).
+\code{set_property()} and \code{map_property()} return the modified huxtable.
 }
 \description{
 \code{width()} sets the width of the entire table, while \code{\link[=col_width]{col_width()}} sets the
@@ -27,9 +28,8 @@ f the surrounding block width (HTML) or text width (LaTeX). A character width
 must be a valid CSS or LaTeX dimension.
 }
 \examples{
+set_width(jams, 0.8)
 
-width(jams) <-  0.8
-width(jams)
 }
 \seealso{
 Other table measurements: 

--- a/man/wrap.Rd
+++ b/man/wrap.Rd
@@ -18,7 +18,7 @@ map_wrap(ht, row, col, fn)
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{value}{A logical vector or matrix. Set to \code{NA} to reset to the default, which is TRUE.}
+\item{value}{A logical vector or matrix. Set to \code{NA} to reset to the default, which is \code{TRUE}.}
 
 \item{row}{A row specifier. See \link{rowspecs} for details.}
 


### PR DESCRIPTION
## Summary
- add shared return docs to `hux_prop_params` describing property getters and setters
- inherit table property docs from `hux_prop_params` instead of `position`
- quote default values via `rd_default` so documentation renders defaults as code

## Testing
- `devtools::document()` *(fails: missing packages openxlsx, dplyr, flextable, lmtest)*
- `devtools::test(filter = "attributes")`


------
https://chatgpt.com/codex/tasks/task_e_689676b9886c8330b810d996e778feaf