### PR TITLE
refactor: inline property checks

### DIFF
--- a/R/properties-border-set-map.R
+++ b/R/properties-border-set-map.R
@@ -1,7 +1,11 @@
 # helper functions -----------------------------------------------------------
 
-
-.border_prop_set <- function(ht, row, col, value, side, prop) {
+#' Set a border property on a subset
+#'
+#' Internal helper for border setters.
+#'
+#' @noRd
+border_prop_set <- function(ht, row, col, value, side, prop) {
   if (missing(col) && missing(value)) {
     value <- row
     row <- seq_len(nrow(ht))
@@ -29,7 +33,12 @@
   ht
 }
 
-.border_prop_map <- function(ht, row, col, fn, side, prop) {
+#' Map a function over a border property
+#'
+#' Internal helper for border mappers.
+#'
+#' @noRd
+border_prop_map <- function(ht, row, col, fn, side, prop) {
   if (missing(col) && missing(fn)) {
     fn <- row
     row <- seq_len(nrow(ht))
@@ -60,7 +69,12 @@
   ht
 }
 
-.border_set <- function(ht, row, col, value, side,
+#' Wrapper to handle default border arguments
+#'
+#' Internal helper for user-facing border setters.
+#'
+#' @noRd
+border_set <- function(ht, row, col, value, side,
                         missing_row, missing_col, missing_value) {
   if (missing_row && missing_col && missing_value) {
     row <- seq_len(nrow(ht))
@@ -75,7 +89,7 @@
     if (missing_col) col <- seq_len(ncol(ht))
     if (missing_value) value <- 0.4
   }
-  .border_prop_set(ht, row, col, value, side, "border")
+  border_prop_set(ht, row, col, value, side, "border")
 }
 
 allowed_border_styles <- c("solid", "double", "dashed", "dotted")
@@ -121,7 +135,7 @@ NULL
 #' @rdname borders
 #' @export
 set_left_border <- function(ht, row, col, value = 0.4) {
-  .border_set(
+  border_set(
     ht, row, col, value, "left",
     missing(row), missing(col), missing(value)
   )
@@ -130,7 +144,7 @@ set_left_border <- function(ht, row, col, value = 0.4) {
 #' @rdname borders
 #' @export
 set_right_border <- function(ht, row, col, value = 0.4) {
-  .border_set(
+  border_set(
     ht, row, col, value, "right",
     missing(row), missing(col), missing(value)
   )
@@ -139,7 +153,7 @@ set_right_border <- function(ht, row, col, value = 0.4) {
 #' @rdname borders
 #' @export
 set_top_border <- function(ht, row, col, value = 0.4) {
-  .border_set(
+  border_set(
     ht, row, col, value, "top",
     missing(row), missing(col), missing(value)
   )
@@ -148,7 +162,7 @@ set_top_border <- function(ht, row, col, value = 0.4) {
 #' @rdname borders
 #' @export
 set_bottom_border <- function(ht, row, col, value = 0.4) {
-  .border_set(
+  border_set(
     ht, row, col, value, "bottom",
     missing(row), missing(col), missing(value)
   )
@@ -157,25 +171,25 @@ set_bottom_border <- function(ht, row, col, value = 0.4) {
 #' @rdname borders
 #' @export
 map_left_border <- function(ht, row, col, fn) {
-  .border_prop_map(ht, row, col, fn, "left", "border")
+  border_prop_map(ht, row, col, fn, "left", "border")
 }
 
 #' @rdname borders
 #' @export
 map_right_border <- function(ht, row, col, fn) {
-  .border_prop_map(ht, row, col, fn, "right", "border")
+  border_prop_map(ht, row, col, fn, "right", "border")
 }
 
 #' @rdname borders
 #' @export
 map_top_border <- function(ht, row, col, fn) {
-  .border_prop_map(ht, row, col, fn, "top", "border")
+  border_prop_map(ht, row, col, fn, "top", "border")
 }
 
 #' @rdname borders
 #' @export
 map_bottom_border <- function(ht, row, col, fn) {
-  .border_prop_map(ht, row, col, fn, "bottom", "border")
+  border_prop_map(ht, row, col, fn, "bottom", "border")
 }
 
 # color ---------------------------------------------------------------------
@@ -209,49 +223,49 @@ NULL
 #' @rdname border-colors
 #' @export
 set_left_border_color <- function(ht, row, col, value) {
-  .border_prop_set(ht, row, col, value, "left", "border_color")
+  border_prop_set(ht, row, col, value, "left", "border_color")
 }
 
 #' @rdname border-colors
 #' @export
 set_right_border_color <- function(ht, row, col, value) {
-  .border_prop_set(ht, row, col, value, "right", "border_color")
+  border_prop_set(ht, row, col, value, "right", "border_color")
 }
 
 #' @rdname border-colors
 #' @export
 set_top_border_color <- function(ht, row, col, value) {
-  .border_prop_set(ht, row, col, value, "top", "border_color")
+  border_prop_set(ht, row, col, value, "top", "border_color")
 }
 
 #' @rdname border-colors
 #' @export
 set_bottom_border_color <- function(ht, row, col, value) {
-  .border_prop_set(ht, row, col, value, "bottom", "border_color")
+  border_prop_set(ht, row, col, value, "bottom", "border_color")
 }
 
 #' @rdname border-colors
 #' @export
 map_left_border_color <- function(ht, row, col, fn) {
-  .border_prop_map(ht, row, col, fn, "left", "border_color")
+  border_prop_map(ht, row, col, fn, "left", "border_color")
 }
 
 #' @rdname border-colors
 #' @export
 map_right_border_color <- function(ht, row, col, fn) {
-  .border_prop_map(ht, row, col, fn, "right", "border_color")
+  border_prop_map(ht, row, col, fn, "right", "border_color")
 }
 
 #' @rdname border-colors
 #' @export
 map_top_border_color <- function(ht, row, col, fn) {
-  .border_prop_map(ht, row, col, fn, "top", "border_color")
+  border_prop_map(ht, row, col, fn, "top", "border_color")
 }
 
 #' @rdname border-colors
 #' @export
 map_bottom_border_color <- function(ht, row, col, fn) {
-  .border_prop_map(ht, row, col, fn, "bottom", "border_color")
+  border_prop_map(ht, row, col, fn, "bottom", "border_color")
 }
 
 # style ---------------------------------------------------------------------
@@ -286,47 +300,47 @@ NULL
 #' @rdname border-styles
 #' @export
 set_left_border_style <- function(ht, row, col, value) {
-  .border_prop_set(ht, row, col, value, "left", "border_style")
+  border_prop_set(ht, row, col, value, "left", "border_style")
 }
 
 #' @rdname border-styles
 #' @export
 set_right_border_style <- function(ht, row, col, value) {
-  .border_prop_set(ht, row, col, value, "right", "border_style")
+  border_prop_set(ht, row, col, value, "right", "border_style")
 }
 
 #' @rdname border-styles
 #' @export
 set_top_border_style <- function(ht, row, col, value) {
-  .border_prop_set(ht, row, col, value, "top", "border_style")
+  border_prop_set(ht, row, col, value, "top", "border_style")
 }
 
 #' @rdname border-styles
 #' @export
 set_bottom_border_style <- function(ht, row, col, value) {
-  .border_prop_set(ht, row, col, value, "bottom", "border_style")
+  border_prop_set(ht, row, col, value, "bottom", "border_style")
 }
 
 #' @rdname border-styles
 #' @export
 map_left_border_style <- function(ht, row, col, fn) {
-  .border_prop_map(ht, row, col, fn, "left", "border_style")
+  border_prop_map(ht, row, col, fn, "left", "border_style")
 }
 
 #' @rdname border-styles
 #' @export
 map_right_border_style <- function(ht, row, col, fn) {
-  .border_prop_map(ht, row, col, fn, "right", "border_style")
+  border_prop_map(ht, row, col, fn, "right", "border_style")
 }
 
 #' @rdname border-styles
 #' @export
 map_top_border_style <- function(ht, row, col, fn) {
-  .border_prop_map(ht, row, col, fn, "top", "border_style")
+  border_prop_map(ht, row, col, fn, "top", "border_style")
 }
 
 #' @rdname border-styles
 #' @export
 map_bottom_border_style <- function(ht, row, col, fn) {
-  .border_prop_map(ht, row, col, fn, "bottom", "border_style")
+  border_prop_map(ht, row, col, fn, "bottom", "border_style")
 }

--- a/R/properties-cell.R
+++ b/R/properties-cell.R
@@ -58,6 +58,7 @@ set_valign <- function(ht, row, col, value) {
 #' @export
 map_valign <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value,
@@ -162,6 +163,7 @@ set_align <- function(ht, row, col, value) {
 #' @export
 map_align <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, check_align_value(value))
@@ -243,6 +245,7 @@ set_rowspan <- function(ht, row, col, value) {
 #' @export
 map_rowspan <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   rcrow <- get_rc_spec(ht, args$row, 1)
   rccol <- get_rc_spec(ht, args$col, 2)
   wrapped_fn <- function(ht, r, c, current) {
@@ -311,6 +314,7 @@ set_colspan <- function(ht, row, col, value) {
 #' @export
 map_colspan <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   rcrow <- get_rc_spec(ht, args$row, 1)
   rccol <- get_rc_spec(ht, args$col, 2)
   wrapped_fn <- function(ht, r, c, current) {
@@ -492,6 +496,7 @@ set_wrap <- function(ht, row, col, value) {
 #' @export
 map_wrap <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.logical(value))
@@ -552,6 +557,7 @@ set_escape_contents <- function(ht, row, col, value) {
 #' @export
 map_escape_contents <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.logical(value))
@@ -627,6 +633,7 @@ set_markdown <- function(ht, row, col, value = TRUE) {
 #' @export
 map_markdown <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.logical(value))
@@ -678,6 +685,7 @@ set_na_string <- function(ht, row, col, value) {
 #' @export
 map_na_string <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.character(value))
@@ -735,6 +743,7 @@ set_bold <- function(ht, row, col, value = TRUE) {
 #' @export
 map_bold <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.logical(value))
@@ -767,6 +776,7 @@ set_italic <- function(ht, row, col, value = TRUE) {
 #' @export
 map_italic <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.logical(value))
@@ -835,6 +845,7 @@ set_font_size <- function(ht, row, col, value) {
 #' @export
 map_font_size <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.numeric(value))
@@ -913,6 +924,7 @@ set_rotation <- function(ht, row, col, value) {
 #' @export
 map_rotation <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.numeric(value))
@@ -1033,6 +1045,7 @@ set_number_format <- function(ht, row, col, value) {
 #' @export
 map_number_format <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, check_number_format(value))
@@ -1157,6 +1170,7 @@ set_font <- function(ht, row, col, value) {
 #' @export
 map_font <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
+  fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.character(value))

--- a/R/properties-cell.R
+++ b/R/properties-cell.R
@@ -46,19 +46,18 @@ valign <- function(ht) prop_get(ht, "valign")
 #' @export
 set_valign <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
-  row <- args$row; col <- args$col; value <- args$value
+  value <- args$value
   assert_not_all_na(value,
     is.character(value),
     all(na.omit(value) %in% c("top", "middle", "bottom"))
   )
-  prop_set(ht, row, col, value, "valign")
+  prop_set(ht, args$row, args$col, value, "valign", prepped = TRUE)
 }
 
 #' @rdname valign
 #' @export
 map_valign <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
-  row <- args$row; col <- args$col; fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value,
@@ -67,7 +66,7 @@ map_valign <- function(ht, row, col, fn) {
     )
     value
   }
-  prop_map(ht, row, col, wrapped_fn, "valign")
+  prop_map(ht, args$row, args$col, wrapped_fn, "valign", prepped = TRUE)
 }
 
 
@@ -153,24 +152,23 @@ align <- function(ht) prop_get(ht, "align")
 #' @export
 set_align <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
-  row <- args$row; col <- args$col; value <- args$value
+  value <- args$value
   assert_not_all_na(value, check_align_value(value))
   value[value == "centre"] <- "center"
-  prop_set(ht, row, col, value, "align")
+  prop_set(ht, args$row, args$col, value, "align", prepped = TRUE)
 }
 
 #' @rdname align
 #' @export
 map_align <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
-  row <- args$row; col <- args$col; fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, check_align_value(value))
     value[value == "centre"] <- "center"
     value
   }
-  prop_map(ht, row, col, wrapped_fn, "align")
+  prop_map(ht, args$row, args$col, wrapped_fn, "align", prepped = TRUE)
 }
 
 
@@ -238,22 +236,15 @@ set_rowspan <- function(ht, row, col, value) {
   if (any(value > 1)) {
     ht <- overwrite_shadowed_cells(ht, dc)
   }
-  prop_set(ht, rcrow, rccol, value, "rowspan")
+  prop_set(ht, rcrow, rccol, value, "rowspan", prepped = TRUE)
 }
 
 #' @rdname spans
 #' @export
 map_rowspan <- function(ht, row, col, fn) {
-  if (missing(col) && missing(fn)) {
-    fn <- row
-    row <- seq_len(nrow(ht))
-    col <- seq_len(ncol(ht))
-  } else {
-    if (missing(row)) row <- seq_len(nrow(ht))
-    if (missing(col)) col <- seq_len(ncol(ht))
-  }
-  rcrow <- get_rc_spec(ht, row, 1)
-  rccol <- get_rc_spec(ht, col, 2)
+  args <- prep_map_args(ht, row, col, fn)
+  rcrow <- get_rc_spec(ht, args$row, 1)
+  rccol <- get_rc_spec(ht, args$col, 2)
   wrapped_fn <- function(ht, r, c, current) {
     value <- fn(ht, r, c, current)
     assert_not_all_na(value, is.numeric(value))
@@ -264,7 +255,7 @@ map_rowspan <- function(ht, row, col, fn) {
     }
     value
   }
-  ht <- prop_map(ht, row, col, wrapped_fn, "rowspan")
+  ht <- prop_map(ht, rcrow, rccol, wrapped_fn, "rowspan", prepped = TRUE)
   new_rs <- attr(ht, "rowspan")
   vals <- new_rs[rcrow, rccol]
   dc <- display_cells(ht, new_rowspan = new_rs)
@@ -313,22 +304,15 @@ set_colspan <- function(ht, row, col, value) {
   if (any(value > 1)) {
     ht <- overwrite_shadowed_cells(ht, dc)
   }
-  prop_set(ht, rcrow, rccol, value, "colspan")
+  prop_set(ht, rcrow, rccol, value, "colspan", prepped = TRUE)
 }
 
 #' @rdname spans
 #' @export
 map_colspan <- function(ht, row, col, fn) {
-  if (missing(col) && missing(fn)) {
-    fn <- row
-    row <- seq_len(nrow(ht))
-    col <- seq_len(ncol(ht))
-  } else {
-    if (missing(row)) row <- seq_len(nrow(ht))
-    if (missing(col)) col <- seq_len(ncol(ht))
-  }
-  rcrow <- get_rc_spec(ht, row, 1)
-  rccol <- get_rc_spec(ht, col, 2)
+  args <- prep_map_args(ht, row, col, fn)
+  rcrow <- get_rc_spec(ht, args$row, 1)
+  rccol <- get_rc_spec(ht, args$col, 2)
   wrapped_fn <- function(ht, r, c, current) {
     value <- fn(ht, r, c, current)
     assert_not_all_na(value, is.numeric(value))
@@ -339,7 +323,7 @@ map_colspan <- function(ht, row, col, fn) {
     }
     value
   }
-  ht <- prop_map(ht, row, col, wrapped_fn, "colspan")
+  ht <- prop_map(ht, rcrow, rccol, wrapped_fn, "colspan", prepped = TRUE)
   new_cs <- attr(ht, "colspan")
   vals <- new_cs[rcrow, rccol]
   dc <- display_cells(ht, new_colspan = new_cs)
@@ -499,22 +483,21 @@ wrap <- function(ht) prop_get(ht, "wrap")
 #' @export
 set_wrap <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
-  row <- args$row; col <- args$col; value <- args$value
+  value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set(ht, row, col, value, "wrap")
+  prop_set(ht, args$row, args$col, value, "wrap", prepped = TRUE)
 }
 
 #' @rdname wrap
 #' @export
 map_wrap <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
-  row <- args$row; col <- args$col; fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.logical(value))
     value
   }
-  prop_map(ht, row, col, wrapped_fn, "wrap")
+  prop_map(ht, args$row, args$col, wrapped_fn, "wrap", prepped = TRUE)
 }
 
 
@@ -560,22 +543,21 @@ escape_contents <- function(ht) prop_get(ht, "escape_contents")
 #' @export
 set_escape_contents <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
-  row <- args$row; col <- args$col; value <- args$value
+  value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set(ht, row, col, value, "escape_contents")
+  prop_set(ht, args$row, args$col, value, "escape_contents", prepped = TRUE)
 }
 
 #' @rdname escape_contents
 #' @export
 map_escape_contents <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
-  row <- args$row; col <- args$col; fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.logical(value))
     value
   }
-  prop_map(ht, row, col, wrapped_fn, "escape_contents")
+  prop_map(ht, args$row, args$col, wrapped_fn, "escape_contents", prepped = TRUE)
 }
 
 
@@ -636,22 +618,21 @@ markdown <- function(ht) prop_get(ht, "markdown")
 #' @export
 set_markdown <- function(ht, row, col, value = TRUE) {
   args <- prep_set_args(ht, row, col, value)
-  row <- args$row; col <- args$col; value <- args$value
+  value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set(ht, row, col, value, "markdown")
+  prop_set(ht, args$row, args$col, value, "markdown", prepped = TRUE)
 }
 
 #' @rdname markdown
 #' @export
 map_markdown <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
-  row <- args$row; col <- args$col; fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.logical(value))
     value
   }
-  prop_map(ht, row, col, wrapped_fn, "markdown")
+  prop_map(ht, args$row, args$col, wrapped_fn, "markdown", prepped = TRUE)
 }
 
 
@@ -688,22 +669,21 @@ na_string <- function(ht) prop_get(ht, "na_string")
 #' @export
 set_na_string <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
-  row <- args$row; col <- args$col; value <- args$value
+  value <- args$value
   assert_not_all_na(value, is.character(value))
-  prop_set(ht, row, col, value, "na_string")
+  prop_set(ht, args$row, args$col, value, "na_string", prepped = TRUE)
 }
 
 #' @rdname na_string
 #' @export
 map_na_string <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
-  row <- args$row; col <- args$col; fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.character(value))
     value
   }
-  prop_map(ht, row, col, wrapped_fn, "na_string")
+  prop_map(ht, args$row, args$col, wrapped_fn, "na_string", prepped = TRUE)
 }
 
 
@@ -746,22 +726,21 @@ bold <- function(ht) prop_get(ht, "bold")
 #' @export
 set_bold <- function(ht, row, col, value = TRUE) {
   args <- prep_set_args(ht, row, col, value)
-  row <- args$row; col <- args$col; value <- args$value
+  value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set(ht, row, col, value, "bold")
+  prop_set(ht, args$row, args$col, value, "bold", prepped = TRUE)
 }
 
 #' @rdname bold
 #' @export
 map_bold <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
-  row <- args$row; col <- args$col; fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.logical(value))
     value
   }
-  prop_map(ht, row, col, wrapped_fn, "bold")
+  prop_map(ht, args$row, args$col, wrapped_fn, "bold", prepped = TRUE)
 }
 
 #' @rdname bold
@@ -779,22 +758,21 @@ italic <- function(ht) prop_get(ht, "italic")
 #' @export
 set_italic <- function(ht, row, col, value = TRUE) {
   args <- prep_set_args(ht, row, col, value)
-  row <- args$row; col <- args$col; value <- args$value
+  value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set(ht, row, col, value, "italic")
+  prop_set(ht, args$row, args$col, value, "italic", prepped = TRUE)
 }
 
 #' @rdname bold
 #' @export
 map_italic <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
-  row <- args$row; col <- args$col; fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.logical(value))
     value
   }
-  prop_map(ht, row, col, wrapped_fn, "italic")
+  prop_map(ht, args$row, args$col, wrapped_fn, "italic", prepped = TRUE)
 }
 #' Make text larger or smaller
 #'
@@ -848,22 +826,21 @@ font_size <- function(ht) prop_get(ht, "font_size")
 #' @export
 set_font_size <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
-  row <- args$row; col <- args$col; value <- args$value
+  value <- args$value
   assert_not_all_na(value, is.numeric(value))
-  prop_set(ht, row, col, value, "font_size")
+  prop_set(ht, args$row, args$col, value, "font_size", prepped = TRUE)
 }
 
 #' @rdname font_size
 #' @export
 map_font_size <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
-  row <- args$row; col <- args$col; fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.numeric(value))
     value
   }
-  prop_map(ht, row, col, wrapped_fn, "font_size")
+  prop_map(ht, args$row, args$col, wrapped_fn, "font_size", prepped = TRUE)
 }
 
 
@@ -926,24 +903,23 @@ rotation <- function(ht) prop_get(ht, "rotation")
 #' @export
 set_rotation <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
-  row <- args$row; col <- args$col; value <- args$value
+  value <- args$value
   assert_not_all_na(value, is.numeric(value))
   value <- value %% 360
-  prop_set(ht, row, col, value, "rotation")
+  prop_set(ht, args$row, args$col, value, "rotation", prepped = TRUE)
 }
 
 #' @rdname rotation
 #' @export
 map_rotation <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
-  row <- args$row; col <- args$col; fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.numeric(value))
     value <- value %% 360
     value
   }
-  prop_map(ht, row, col, wrapped_fn, "rotation")
+  prop_map(ht, args$row, args$col, wrapped_fn, "rotation", prepped = TRUE)
 }
 
 
@@ -1046,10 +1022,10 @@ number_format <- function(ht) prop_get(ht, "number_format")
 #' @export
 set_number_format <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
-  row <- args$row; col <- args$col; value <- args$value
+  value <- args$value
   assert_not_all_na(value, check_number_format(value))
-  prop_set(ht, row, col, value, "number_format",
-    reset_na = FALSE
+  prop_set(ht, args$row, args$col, value, "number_format",
+    reset_na = FALSE, prepped = TRUE
   )
 }
 
@@ -1057,13 +1033,12 @@ set_number_format <- function(ht, row, col, value) {
 #' @export
 map_number_format <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
-  row <- args$row; col <- args$col; fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, check_number_format(value))
     value
   }
-  prop_map(ht, row, col, wrapped_fn, "number_format", reset_na = FALSE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "number_format", reset_na = FALSE, prepped = TRUE)
 }
 
 
@@ -1173,20 +1148,19 @@ font <- function(ht) prop_get(ht, "font")
 #' @export
 set_font <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
-  row <- args$row; col <- args$col; value <- args$value
+  value <- args$value
   assert_not_all_na(value, is.character(value))
-  prop_set(ht, row, col, value, "font")
+  prop_set(ht, args$row, args$col, value, "font", prepped = TRUE)
 }
 
 #' @rdname font
 #' @export
 map_font <- function(ht, row, col, fn) {
   args <- prep_map_args(ht, row, col, fn)
-  row <- args$row; col <- args$col; fn <- args$fn
   wrapped_fn <- function(ht, row, col, current) {
     value <- fn(ht, row, col, current)
     assert_not_all_na(value, is.character(value))
     value
   }
-  prop_map(ht, row, col, wrapped_fn, "font")
+  prop_map(ht, args$row, args$col, wrapped_fn, "font", prepped = TRUE)
 }

--- a/R/properties-cell.R
+++ b/R/properties-cell.R
@@ -51,7 +51,7 @@ set_valign <- function(ht, row, col, value) {
     is.character(value),
     all(na.omit(value) %in% c("top", "middle", "bottom"))
   )
-  prop_set(ht, args$row, args$col, value, "valign", prepped = TRUE)
+  prop_set(ht, args$row, args$col, value, "valign", prepped = TRUE, env = args$env)
 }
 
 #' @rdname valign
@@ -67,7 +67,7 @@ map_valign <- function(ht, row, col, fn) {
     )
     value
   }
-  prop_map(ht, args$row, args$col, wrapped_fn, "valign", prepped = TRUE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "valign", prepped = TRUE, env = args$env)
 }
 
 
@@ -156,7 +156,7 @@ set_align <- function(ht, row, col, value) {
   value <- args$value
   assert_not_all_na(value, check_align_value(value))
   value[value == "centre"] <- "center"
-  prop_set(ht, args$row, args$col, value, "align", prepped = TRUE)
+  prop_set(ht, args$row, args$col, value, "align", prepped = TRUE, env = args$env)
 }
 
 #' @rdname align
@@ -170,7 +170,7 @@ map_align <- function(ht, row, col, fn) {
     value[value == "centre"] <- "center"
     value
   }
-  prop_map(ht, args$row, args$col, wrapped_fn, "align", prepped = TRUE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "align", prepped = TRUE, env = args$env)
 }
 
 
@@ -489,7 +489,7 @@ set_wrap <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
   value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set(ht, args$row, args$col, value, "wrap", prepped = TRUE)
+  prop_set(ht, args$row, args$col, value, "wrap", prepped = TRUE, env = args$env)
 }
 
 #' @rdname wrap
@@ -502,7 +502,7 @@ map_wrap <- function(ht, row, col, fn) {
     assert_not_all_na(value, is.logical(value))
     value
   }
-  prop_map(ht, args$row, args$col, wrapped_fn, "wrap", prepped = TRUE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "wrap", prepped = TRUE, env = args$env)
 }
 
 
@@ -550,7 +550,7 @@ set_escape_contents <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
   value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set(ht, args$row, args$col, value, "escape_contents", prepped = TRUE)
+  prop_set(ht, args$row, args$col, value, "escape_contents", prepped = TRUE, env = args$env)
 }
 
 #' @rdname escape_contents
@@ -563,7 +563,7 @@ map_escape_contents <- function(ht, row, col, fn) {
     assert_not_all_na(value, is.logical(value))
     value
   }
-  prop_map(ht, args$row, args$col, wrapped_fn, "escape_contents", prepped = TRUE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "escape_contents", prepped = TRUE, env = args$env)
 }
 
 
@@ -626,7 +626,7 @@ set_markdown <- function(ht, row, col, value = TRUE) {
   args <- prep_set_args(ht, row, col, value)
   value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set(ht, args$row, args$col, value, "markdown", prepped = TRUE)
+  prop_set(ht, args$row, args$col, value, "markdown", prepped = TRUE, env = args$env)
 }
 
 #' @rdname markdown
@@ -639,7 +639,7 @@ map_markdown <- function(ht, row, col, fn) {
     assert_not_all_na(value, is.logical(value))
     value
   }
-  prop_map(ht, args$row, args$col, wrapped_fn, "markdown", prepped = TRUE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "markdown", prepped = TRUE, env = args$env)
 }
 
 
@@ -678,7 +678,7 @@ set_na_string <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
   value <- args$value
   assert_not_all_na(value, is.character(value))
-  prop_set(ht, args$row, args$col, value, "na_string", prepped = TRUE)
+  prop_set(ht, args$row, args$col, value, "na_string", prepped = TRUE, env = args$env)
 }
 
 #' @rdname na_string
@@ -691,7 +691,7 @@ map_na_string <- function(ht, row, col, fn) {
     assert_not_all_na(value, is.character(value))
     value
   }
-  prop_map(ht, args$row, args$col, wrapped_fn, "na_string", prepped = TRUE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "na_string", prepped = TRUE, env = args$env)
 }
 
 
@@ -736,7 +736,7 @@ set_bold <- function(ht, row, col, value = TRUE) {
   args <- prep_set_args(ht, row, col, value)
   value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set(ht, args$row, args$col, value, "bold", prepped = TRUE)
+  prop_set(ht, args$row, args$col, value, "bold", prepped = TRUE, env = args$env)
 }
 
 #' @rdname bold
@@ -749,7 +749,7 @@ map_bold <- function(ht, row, col, fn) {
     assert_not_all_na(value, is.logical(value))
     value
   }
-  prop_map(ht, args$row, args$col, wrapped_fn, "bold", prepped = TRUE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "bold", prepped = TRUE, env = args$env)
 }
 
 #' @rdname bold
@@ -769,7 +769,7 @@ set_italic <- function(ht, row, col, value = TRUE) {
   args <- prep_set_args(ht, row, col, value)
   value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set(ht, args$row, args$col, value, "italic", prepped = TRUE)
+  prop_set(ht, args$row, args$col, value, "italic", prepped = TRUE, env = args$env)
 }
 
 #' @rdname bold
@@ -782,7 +782,7 @@ map_italic <- function(ht, row, col, fn) {
     assert_not_all_na(value, is.logical(value))
     value
   }
-  prop_map(ht, args$row, args$col, wrapped_fn, "italic", prepped = TRUE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "italic", prepped = TRUE, env = args$env)
 }
 #' Make text larger or smaller
 #'
@@ -838,7 +838,7 @@ set_font_size <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
   value <- args$value
   assert_not_all_na(value, is.numeric(value))
-  prop_set(ht, args$row, args$col, value, "font_size", prepped = TRUE)
+  prop_set(ht, args$row, args$col, value, "font_size", prepped = TRUE, env = args$env)
 }
 
 #' @rdname font_size
@@ -851,7 +851,7 @@ map_font_size <- function(ht, row, col, fn) {
     assert_not_all_na(value, is.numeric(value))
     value
   }
-  prop_map(ht, args$row, args$col, wrapped_fn, "font_size", prepped = TRUE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "font_size", prepped = TRUE, env = args$env)
 }
 
 
@@ -917,7 +917,7 @@ set_rotation <- function(ht, row, col, value) {
   value <- args$value
   assert_not_all_na(value, is.numeric(value))
   value <- value %% 360
-  prop_set(ht, args$row, args$col, value, "rotation", prepped = TRUE)
+  prop_set(ht, args$row, args$col, value, "rotation", prepped = TRUE, env = args$env)
 }
 
 #' @rdname rotation
@@ -931,7 +931,7 @@ map_rotation <- function(ht, row, col, fn) {
     value <- value %% 360
     value
   }
-  prop_map(ht, args$row, args$col, wrapped_fn, "rotation", prepped = TRUE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "rotation", prepped = TRUE, env = args$env)
 }
 
 
@@ -1037,7 +1037,7 @@ set_number_format <- function(ht, row, col, value) {
   value <- args$value
   assert_not_all_na(value, check_number_format(value))
   prop_set(ht, args$row, args$col, value, "number_format",
-    reset_na = FALSE, prepped = TRUE
+    reset_na = FALSE, prepped = TRUE, env = args$env
   )
 }
 
@@ -1051,7 +1051,7 @@ map_number_format <- function(ht, row, col, fn) {
     assert_not_all_na(value, check_number_format(value))
     value
   }
-  prop_map(ht, args$row, args$col, wrapped_fn, "number_format", reset_na = FALSE, prepped = TRUE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "number_format", reset_na = FALSE, prepped = TRUE, env = args$env)
 }
 
 
@@ -1163,7 +1163,7 @@ set_font <- function(ht, row, col, value) {
   args <- prep_set_args(ht, row, col, value)
   value <- args$value
   assert_not_all_na(value, is.character(value))
-  prop_set(ht, args$row, args$col, value, "font", prepped = TRUE)
+  prop_set(ht, args$row, args$col, value, "font", prepped = TRUE, env = args$env)
 }
 
 #' @rdname font
@@ -1176,5 +1176,5 @@ map_font <- function(ht, row, col, fn) {
     assert_not_all_na(value, is.character(value))
     value
   }
-  prop_map(ht, args$row, args$col, wrapped_fn, "font", prepped = TRUE)
+  prop_map(ht, args$row, args$col, wrapped_fn, "font", prepped = TRUE, env = args$env)
 }

--- a/R/properties-cell.R
+++ b/R/properties-cell.R
@@ -35,27 +35,33 @@ valign <- function(ht) prop_get(ht, "valign")
 #' @rdname valign
 #' @export
 `valign<-` <- function(ht, value) {
-  prop_replace(ht, value, "valign",
-    check_fun = is.character,
-    check_values = c("top", "middle", "bottom")
-  )
+  if (!all(is.na(value))) {
+    assert_that(is.character(value))
+    assert_that(all(na.omit(value) %in% c("top", "middle", "bottom")))
+  }
+  prop_replace(ht, value, "valign")
 }
 
 #' @rdname valign
 #' @export
 set_valign <- function(ht, row, col, value) {
-  prop_set(ht, row, col, value, "valign",
-    check_fun = is.character,
-    check_values = c("top", "middle", "bottom")
-  )
+  if (!all(is.na(value))) {
+    assert_that(is.character(value))
+    assert_that(all(na.omit(value) %in% c("top", "middle", "bottom")))
+  }
+  prop_set(ht, row, col, value, "valign")
 }
 
 #' @rdname valign
 #' @export
 map_valign <- function(ht, row, col, fn) {
   prop_map(ht, row, col, fn, "valign",
-    check_fun = is.character,
-    check_values = c("top", "middle", "bottom")
+    extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(is.character(value))
+        assert_that(all(na.omit(value) %in% c("top", "middle", "bottom")))
+      }
+    })
   )
 }
 
@@ -133,27 +139,33 @@ align <- function(ht) prop_get(ht, "align")
 #' @rdname align
 #' @export
 `align<-` <- function(ht, value) {
-  prop_replace(ht, value, "align",
-    check_fun = check_align_value,
-    extra = quote(value[value == "centre"] <- "center")
-  )
+  if (!all(is.na(value))) {
+    assert_that(check_align_value(value))
+  }
+  value[value == "centre"] <- "center"
+  prop_replace(ht, value, "align")
 }
 
 #' @rdname align
 #' @export
 set_align <- function(ht, row, col, value) {
-  prop_set(ht, row, col, value, "align",
-    check_fun = check_align_value,
-    extra = quote(value[value == "centre"] <- "center")
-  )
+  if (!all(is.na(value))) {
+    assert_that(check_align_value(value))
+  }
+  value[value == "centre"] <- "center"
+  prop_set(ht, row, col, value, "align")
 }
 
 #' @rdname align
 #' @export
 map_align <- function(ht, row, col, fn) {
   prop_map(ht, row, col, fn, "align",
-    check_fun = check_align_value,
-    extra = quote(value[value == "centre"] <- "center")
+    extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(check_align_value(value))
+      }
+      value[value == "centre"] <- "center"
+    })
   )
 }
 
@@ -191,8 +203,10 @@ rowspan <- function(ht) prop_get(ht, "rowspan")
 #' @rdname spans
 #' @export
 `rowspan<-` <- function(ht, value) {
+  if (!all(is.na(value))) {
+    assert_that(is.numeric(value))
+  }
   prop_replace(ht, value, "rowspan",
-    check_fun = is.numeric,
     extra = quote({
       too_long <- na.omit(base::row(ht) + value - 1 > nrow(ht))
       if (any(too_long)) {
@@ -209,8 +223,10 @@ rowspan <- function(ht) prop_get(ht, "rowspan")
 #' @rdname spans
 #' @export
 set_rowspan <- function(ht, row, col, value) {
+  if (!all(is.na(value))) {
+    assert_that(is.numeric(value))
+  }
   prop_set(ht, row, col, value, "rowspan",
-    check_fun = is.numeric,
     extra = quote({
       rows <- base::row(ht)[rc$row, rc$col, drop = FALSE]
       too_long <- na.omit(rows + value - 1 > nrow(ht))
@@ -231,8 +247,10 @@ set_rowspan <- function(ht, row, col, value) {
 #' @export
 map_rowspan <- function(ht, row, col, fn) {
   prop_map(ht, row, col, fn, "rowspan",
-    check_fun = is.numeric,
     extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(is.numeric(value))
+      }
       rows <- base::row(ht)[rc$row, rc$col, drop = FALSE]
       too_long <- na.omit(rows + value - 1 > nrow(ht))
       if (any(too_long)) {
@@ -256,8 +274,10 @@ colspan <- function(ht) prop_get(ht, "colspan")
 #' @rdname spans
 #' @export
 `colspan<-` <- function(ht, value) {
+  if (!all(is.na(value))) {
+    assert_that(is.numeric(value))
+  }
   prop_replace(ht, value, "colspan",
-    check_fun = is.numeric,
     extra = quote({
       too_long <- na.omit(base::col(ht) + value - 1 > ncol(ht))
       if (any(too_long)) {
@@ -274,8 +294,10 @@ colspan <- function(ht) prop_get(ht, "colspan")
 #' @rdname spans
 #' @export
 set_colspan <- function(ht, row, col, value) {
+  if (!all(is.na(value))) {
+    assert_that(is.numeric(value))
+  }
   prop_set(ht, row, col, value, "colspan",
-    check_fun = is.numeric,
     extra = quote({
       cols <- base::col(ht)[rc$row, rc$col, drop = FALSE]
       too_long <- na.omit(cols + value - 1 > ncol(ht))
@@ -296,8 +318,10 @@ set_colspan <- function(ht, row, col, value) {
 #' @export
 map_colspan <- function(ht, row, col, fn) {
   prop_map(ht, row, col, fn, "colspan",
-    check_fun = is.numeric,
     extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(is.numeric(value))
+      }
       cols <- base::col(ht)[rc$row, rc$col, drop = FALSE]
       too_long <- na.omit(cols + value - 1 > ncol(ht))
       if (any(too_long)) {
@@ -455,19 +479,31 @@ wrap <- function(ht) prop_get(ht, "wrap")
 #' @rdname wrap
 #' @export
 `wrap<-` <- function(ht, value) {
-  prop_replace(ht, value, "wrap", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_replace(ht, value, "wrap")
 }
 
 #' @rdname wrap
 #' @export
 set_wrap <- function(ht, row, col, value) {
-  prop_set(ht, row, col, value, "wrap", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_set(ht, row, col, value, "wrap")
 }
 
 #' @rdname wrap
 #' @export
 map_wrap <- function(ht, row, col, fn) {
-  prop_map(ht, row, col, fn, "wrap", check_fun = is.logical)
+  prop_map(ht, row, col, fn, "wrap",
+    extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(is.logical(value))
+      }
+    })
+  )
 }
 
 
@@ -505,19 +541,31 @@ escape_contents <- function(ht) prop_get(ht, "escape_contents")
 #' @rdname escape_contents
 #' @export
 `escape_contents<-` <- function(ht, value) {
-  prop_replace(ht, value, "escape_contents", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_replace(ht, value, "escape_contents")
 }
 
 #' @rdname escape_contents
 #' @export
 set_escape_contents <- function(ht, row, col, value) {
-  prop_set(ht, row, col, value, "escape_contents", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_set(ht, row, col, value, "escape_contents")
 }
 
 #' @rdname escape_contents
 #' @export
 map_escape_contents <- function(ht, row, col, fn) {
-  prop_map(ht, row, col, fn, "escape_contents", check_fun = is.logical)
+  prop_map(ht, row, col, fn, "escape_contents",
+    extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(is.logical(value))
+      }
+    })
+  )
 }
 
 
@@ -570,19 +618,31 @@ markdown <- function(ht) prop_get(ht, "markdown")
 #' @rdname markdown
 #' @export
 `markdown<-` <- function(ht, value) {
-  prop_replace(ht, value, "markdown", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_replace(ht, value, "markdown")
 }
 
 #' @rdname markdown
 #' @export
 set_markdown <- function(ht, row, col, value = TRUE) {
-  prop_set(ht, row, col, value, "markdown", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_set(ht, row, col, value, "markdown")
 }
 
 #' @rdname markdown
 #' @export
 map_markdown <- function(ht, row, col, fn) {
-  prop_map(ht, row, col, fn, "markdown", check_fun = is.logical)
+  prop_map(ht, row, col, fn, "markdown",
+    extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(is.logical(value))
+      }
+    })
+  )
 }
 
 
@@ -611,19 +671,31 @@ na_string <- function(ht) prop_get(ht, "na_string")
 #' @rdname na_string
 #' @export
 `na_string<-` <- function(ht, value) {
-  prop_replace(ht, value, "na_string", check_fun = is.character)
+  if (!all(is.na(value))) {
+    assert_that(is.character(value))
+  }
+  prop_replace(ht, value, "na_string")
 }
 
 #' @rdname na_string
 #' @export
 set_na_string <- function(ht, row, col, value) {
-  prop_set(ht, row, col, value, "na_string", check_fun = is.character)
+  if (!all(is.na(value))) {
+    assert_that(is.character(value))
+  }
+  prop_set(ht, row, col, value, "na_string")
 }
 
 #' @rdname na_string
 #' @export
 map_na_string <- function(ht, row, col, fn) {
-  prop_map(ht, row, col, fn, "na_string", check_fun = is.character)
+  prop_map(ht, row, col, fn, "na_string",
+    extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(is.character(value))
+      }
+    })
+  )
 }
 
 
@@ -658,19 +730,31 @@ bold <- function(ht) prop_get(ht, "bold")
 #' @rdname bold
 #' @export
 `bold<-` <- function(ht, value) {
-  prop_replace(ht, value, "bold", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_replace(ht, value, "bold")
 }
 
 #' @rdname bold
 #' @export
 set_bold <- function(ht, row, col, value = TRUE) {
-  prop_set(ht, row, col, value, "bold", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_set(ht, row, col, value, "bold")
 }
 
 #' @rdname bold
 #' @export
 map_bold <- function(ht, row, col, fn) {
-  prop_map(ht, row, col, fn, "bold", check_fun = is.logical)
+  prop_map(ht, row, col, fn, "bold",
+    extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(is.logical(value))
+      }
+    })
+  )
 }
 
 #' @rdname bold
@@ -680,19 +764,31 @@ italic <- function(ht) prop_get(ht, "italic")
 #' @rdname bold
 #' @export
 `italic<-` <- function(ht, value) {
-  prop_replace(ht, value, "italic", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_replace(ht, value, "italic")
 }
 
 #' @rdname bold
 #' @export
 set_italic <- function(ht, row, col, value = TRUE) {
-  prop_set(ht, row, col, value, "italic", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_set(ht, row, col, value, "italic")
 }
 
 #' @rdname bold
 #' @export
 map_italic <- function(ht, row, col, fn) {
-  prop_map(ht, row, col, fn, "italic", check_fun = is.logical)
+  prop_map(ht, row, col, fn, "italic",
+    extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(is.logical(value))
+      }
+    })
+  )
 }
 #' Make text larger or smaller
 #'
@@ -738,19 +834,31 @@ font_size <- function(ht) prop_get(ht, "font_size")
 #' @rdname font_size
 #' @export
 `font_size<-` <- function(ht, value) {
-  prop_replace(ht, value, "font_size", check_fun = is.numeric)
+  if (!all(is.na(value))) {
+    assert_that(is.numeric(value))
+  }
+  prop_replace(ht, value, "font_size")
 }
 
 #' @rdname font_size
 #' @export
 set_font_size <- function(ht, row, col, value) {
-  prop_set(ht, row, col, value, "font_size", check_fun = is.numeric)
+  if (!all(is.na(value))) {
+    assert_that(is.numeric(value))
+  }
+  prop_set(ht, row, col, value, "font_size")
 }
 
 #' @rdname font_size
 #' @export
 map_font_size <- function(ht, row, col, fn) {
-  prop_map(ht, row, col, fn, "font_size", check_fun = is.numeric)
+  prop_map(ht, row, col, fn, "font_size",
+    extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(is.numeric(value))
+      }
+    })
+  )
 }
 
 
@@ -804,8 +912,10 @@ rotation <- function(ht) prop_get(ht, "rotation")
 #' @rdname rotation
 #' @export
 `rotation<-` <- function(ht, value) {
+  if (!all(is.na(value))) {
+    assert_that(is.numeric(value))
+  }
   prop_replace(ht, value, "rotation",
-    check_fun = is.numeric,
     extra = quote(value <- value %% 360)
   )
 }
@@ -813,8 +923,10 @@ rotation <- function(ht) prop_get(ht, "rotation")
 #' @rdname rotation
 #' @export
 set_rotation <- function(ht, row, col, value) {
+  if (!all(is.na(value))) {
+    assert_that(is.numeric(value))
+  }
   prop_set(ht, row, col, value, "rotation",
-    check_fun = is.numeric,
     extra = quote(value <- value %% 360)
   )
 }
@@ -823,8 +935,12 @@ set_rotation <- function(ht, row, col, value) {
 #' @export
 map_rotation <- function(ht, row, col, fn) {
   prop_map(ht, row, col, fn, "rotation",
-    check_fun = is.numeric,
-    extra = quote(value <- value %% 360)
+    extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(is.numeric(value))
+      }
+      value <- value %% 360
+    })
   )
 }
 
@@ -917,8 +1033,10 @@ number_format <- function(ht) prop_get(ht, "number_format")
 #' @rdname number_format
 #' @export
 `number_format<-` <- function(ht, value) {
+  if (!all(is.na(value))) {
+    assert_that(check_number_format(value))
+  }
   prop_replace(ht, value, "number_format",
-    check_fun = check_number_format,
     reset_na = FALSE,
     coerce_mode = FALSE
   )
@@ -927,8 +1045,10 @@ number_format <- function(ht) prop_get(ht, "number_format")
 #' @rdname number_format
 #' @export
 set_number_format <- function(ht, row, col, value) {
+  if (!all(is.na(value))) {
+    assert_that(check_number_format(value))
+  }
   prop_set(ht, row, col, value, "number_format",
-    check_fun = check_number_format,
     reset_na = FALSE
   )
 }
@@ -937,7 +1057,11 @@ set_number_format <- function(ht, row, col, value) {
 #' @export
 map_number_format <- function(ht, row, col, fn) {
   prop_map(ht, row, col, fn, "number_format",
-    check_fun = check_number_format,
+    extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(check_number_format(value))
+      }
+    }),
     reset_na = FALSE
   )
 }
@@ -1041,17 +1165,29 @@ font <- function(ht) prop_get(ht, "font")
 #' @rdname font
 #' @export
 `font<-` <- function(ht, value) {
-  prop_replace(ht, value, "font", check_fun = is.character)
+  if (!all(is.na(value))) {
+    assert_that(is.character(value))
+  }
+  prop_replace(ht, value, "font")
 }
 
 #' @rdname font
 #' @export
 set_font <- function(ht, row, col, value) {
-  prop_set(ht, row, col, value, "font", check_fun = is.character)
+  if (!all(is.na(value))) {
+    assert_that(is.character(value))
+  }
+  prop_set(ht, row, col, value, "font")
 }
 
 #' @rdname font
 #' @export
 map_font <- function(ht, row, col, fn) {
-  prop_map(ht, row, col, fn, "font", check_fun = is.character)
+  prop_map(ht, row, col, fn, "font",
+    extra = quote({
+      if (!all(is.na(value))) {
+        assert_that(is.character(value))
+      }
+    })
+  )
 }

--- a/R/properties-row-col.R
+++ b/R/properties-row-col.R
@@ -40,18 +40,20 @@ col_width <- function(ht) prop_get(ht, "col_width")
 #' @rdname col_width
 #' @export
 `col_width<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is_numeric_or_character(value))
-  }
+  assert_not_all_na(value, is_numeric_or_character(value))
   prop_replace(ht, value, "col_width")
 }
 
 #' @rdname col_width
 #' @export
 set_col_width <- function(ht, col, value) {
-  if (!all(is.na(value))) {
-    assert_that(is_numeric_or_character(value))
+  if (missing(value)) {
+    value <- col
+    col <- seq_len(ncol(ht))
+  } else if (missing(col)) {
+    col <- seq_len(ncol(ht))
   }
+  assert_not_all_na(value, is_numeric_or_character(value))
   prop_set_col(ht, col, value, "col_width")
 }
 
@@ -86,18 +88,20 @@ row_height <- function(ht) prop_get(ht, "row_height")
 #' @rdname row_height
 #' @export
 `row_height<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is_numeric_or_character(value))
-  }
+  assert_not_all_na(value, is_numeric_or_character(value))
   prop_replace(ht, value, "row_height")
 }
 
 #' @rdname row_height
 #' @export
 set_row_height <- function(ht, row, value) {
-  if (!all(is.na(value))) {
-    assert_that(is_numeric_or_character(value))
+  if (missing(value)) {
+    value <- row
+    row <- seq_len(nrow(ht))
+  } else if (missing(row)) {
+    row <- seq_len(nrow(ht))
   }
+  assert_not_all_na(value, is_numeric_or_character(value))
   prop_set_row(ht, row, value, "row_height")
 }
 
@@ -136,18 +140,20 @@ header_cols <- function(ht) prop_get(ht, "header_cols")
 #' @rdname header_cols
 #' @export
 `header_cols<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.logical(value))
-  }
+  assert_not_all_na(value, is.logical(value))
   prop_replace(ht, value, "header_cols")
 }
 
 #' @rdname header_cols
 #' @export
 set_header_cols <- function(ht, col, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.logical(value))
+  if (missing(value)) {
+    value <- col
+    col <- seq_len(ncol(ht))
+  } else if (missing(col)) {
+    col <- seq_len(ncol(ht))
   }
+  assert_not_all_na(value, is.logical(value))
   prop_set_col(ht, col, value, "header_cols")
 }
 
@@ -165,17 +171,19 @@ header_rows <- function(ht) prop_get(ht, "header_rows")
 #' @rdname header_cols
 #' @export
 `header_rows<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.logical(value))
-  }
+  assert_not_all_na(value, is.logical(value))
   prop_replace(ht, value, "header_rows")
 }
 
 #' @rdname header_cols
 #' @export
 set_header_rows <- function(ht, row, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.logical(value))
+  if (missing(value)) {
+    value <- row
+    row <- seq_len(nrow(ht))
+  } else if (missing(row)) {
+    row <- seq_len(nrow(ht))
   }
+  assert_not_all_na(value, is.logical(value))
   prop_set_row(ht, row, value, "header_rows")
 }

--- a/R/properties-row-col.R
+++ b/R/properties-row-col.R
@@ -50,7 +50,7 @@ set_col_width <- function(ht, col, value) {
   args <- prep_index_args(ht, col, value, ncol(ht))
   value <- args$value
   assert_not_all_na(value, is_numeric_or_character(value))
-  prop_set_col(ht, args$idx, value, "col_width", prepped = TRUE)
+  prop_set_col(ht, args$idx, value, "col_width", prepped = TRUE, env = args$env)
 }
 
 
@@ -94,7 +94,7 @@ set_row_height <- function(ht, row, value) {
   args <- prep_index_args(ht, row, value, nrow(ht))
   value <- args$value
   assert_not_all_na(value, is_numeric_or_character(value))
-  prop_set_row(ht, args$idx, value, "row_height", prepped = TRUE)
+  prop_set_row(ht, args$idx, value, "row_height", prepped = TRUE, env = args$env)
 }
 
 
@@ -142,7 +142,7 @@ set_header_cols <- function(ht, col, value) {
   args <- prep_index_args(ht, col, value, ncol(ht))
   value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set_col(ht, args$idx, value, "header_cols", prepped = TRUE)
+  prop_set_col(ht, args$idx, value, "header_cols", prepped = TRUE, env = args$env)
 }
 
 #' @rdname header_cols
@@ -169,5 +169,5 @@ set_header_rows <- function(ht, row, value) {
   args <- prep_index_args(ht, row, value, nrow(ht))
   value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set_row(ht, args$idx, value, "header_rows", prepped = TRUE)
+  prop_set_row(ht, args$idx, value, "header_rows", prepped = TRUE, env = args$env)
 }

--- a/R/properties-row-col.R
+++ b/R/properties-row-col.R
@@ -40,13 +40,19 @@ col_width <- function(ht) prop_get(ht, "col_width")
 #' @rdname col_width
 #' @export
 `col_width<-` <- function(ht, value) {
-  prop_replace(ht, value, "col_width", check_fun = is_numeric_or_character)
+  if (!all(is.na(value))) {
+    assert_that(is_numeric_or_character(value))
+  }
+  prop_replace(ht, value, "col_width")
 }
 
 #' @rdname col_width
 #' @export
 set_col_width <- function(ht, col, value) {
-  prop_set_col(ht, col, value, "col_width", check_fun = is_numeric_or_character)
+  if (!all(is.na(value))) {
+    assert_that(is_numeric_or_character(value))
+  }
+  prop_set_col(ht, col, value, "col_width")
 }
 
 
@@ -80,13 +86,19 @@ row_height <- function(ht) prop_get(ht, "row_height")
 #' @rdname row_height
 #' @export
 `row_height<-` <- function(ht, value) {
-  prop_replace(ht, value, "row_height", check_fun = is_numeric_or_character)
+  if (!all(is.na(value))) {
+    assert_that(is_numeric_or_character(value))
+  }
+  prop_replace(ht, value, "row_height")
 }
 
 #' @rdname row_height
 #' @export
 set_row_height <- function(ht, row, value) {
-  prop_set_row(ht, row, value, "row_height", check_fun = is_numeric_or_character)
+  if (!all(is.na(value))) {
+    assert_that(is_numeric_or_character(value))
+  }
+  prop_set_row(ht, row, value, "row_height")
 }
 
 
@@ -124,13 +136,19 @@ header_cols <- function(ht) prop_get(ht, "header_cols")
 #' @rdname header_cols
 #' @export
 `header_cols<-` <- function(ht, value) {
-  prop_replace(ht, value, "header_cols", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_replace(ht, value, "header_cols")
 }
 
 #' @rdname header_cols
 #' @export
 set_header_cols <- function(ht, col, value) {
-  prop_set_col(ht, col, value, "header_cols", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_set_col(ht, col, value, "header_cols")
 }
 
 #' @rdname header_cols
@@ -147,11 +165,17 @@ header_rows <- function(ht) prop_get(ht, "header_rows")
 #' @rdname header_cols
 #' @export
 `header_rows<-` <- function(ht, value) {
-  prop_replace(ht, value, "header_rows", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_replace(ht, value, "header_rows")
 }
 
 #' @rdname header_cols
 #' @export
 set_header_rows <- function(ht, row, value) {
-  prop_set_row(ht, row, value, "header_rows", check_fun = is.logical)
+  if (!all(is.na(value))) {
+    assert_that(is.logical(value))
+  }
+  prop_set_row(ht, row, value, "header_rows")
 }

--- a/R/properties-row-col.R
+++ b/R/properties-row-col.R
@@ -47,14 +47,10 @@ col_width <- function(ht) prop_get(ht, "col_width")
 #' @rdname col_width
 #' @export
 set_col_width <- function(ht, col, value) {
-  if (missing(value)) {
-    value <- col
-    col <- seq_len(ncol(ht))
-  } else if (missing(col)) {
-    col <- seq_len(ncol(ht))
-  }
+  args <- prep_index_args(ht, col, value, ncol(ht))
+  value <- args$value
   assert_not_all_na(value, is_numeric_or_character(value))
-  prop_set_col(ht, col, value, "col_width")
+  prop_set_col(ht, args$idx, value, "col_width", prepped = TRUE)
 }
 
 
@@ -95,14 +91,10 @@ row_height <- function(ht) prop_get(ht, "row_height")
 #' @rdname row_height
 #' @export
 set_row_height <- function(ht, row, value) {
-  if (missing(value)) {
-    value <- row
-    row <- seq_len(nrow(ht))
-  } else if (missing(row)) {
-    row <- seq_len(nrow(ht))
-  }
+  args <- prep_index_args(ht, row, value, nrow(ht))
+  value <- args$value
   assert_not_all_na(value, is_numeric_or_character(value))
-  prop_set_row(ht, row, value, "row_height")
+  prop_set_row(ht, args$idx, value, "row_height", prepped = TRUE)
 }
 
 
@@ -147,14 +139,10 @@ header_cols <- function(ht) prop_get(ht, "header_cols")
 #' @rdname header_cols
 #' @export
 set_header_cols <- function(ht, col, value) {
-  if (missing(value)) {
-    value <- col
-    col <- seq_len(ncol(ht))
-  } else if (missing(col)) {
-    col <- seq_len(ncol(ht))
-  }
+  args <- prep_index_args(ht, col, value, ncol(ht))
+  value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set_col(ht, col, value, "header_cols")
+  prop_set_col(ht, args$idx, value, "header_cols", prepped = TRUE)
 }
 
 #' @rdname header_cols
@@ -178,12 +166,8 @@ header_rows <- function(ht) prop_get(ht, "header_rows")
 #' @rdname header_cols
 #' @export
 set_header_rows <- function(ht, row, value) {
-  if (missing(value)) {
-    value <- row
-    row <- seq_len(nrow(ht))
-  } else if (missing(row)) {
-    row <- seq_len(nrow(ht))
-  }
+  args <- prep_index_args(ht, row, value, nrow(ht))
+  value <- args$value
   assert_not_all_na(value, is.logical(value))
-  prop_set_row(ht, row, value, "header_rows")
+  prop_set_row(ht, args$idx, value, "header_rows", prepped = TRUE)
 }

--- a/R/properties-table.R
+++ b/R/properties-table.R
@@ -25,9 +25,9 @@ position <- function(ht) prop_get(ht, "position")
 #' @rdname position
 #' @export
 `position<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(all(na.omit(value) %in% c("left", "center", "centre", "right", "wrapleft", "wrapright")))
-  }
+  assert_not_all_na(value,
+    all(na.omit(value) %in% c("left", "center", "centre", "right", "wrapleft", "wrapright"))
+  )
   value[value == "centre"] <- "center"
   prop_replace(ht, value, "position")
 }
@@ -35,9 +35,9 @@ position <- function(ht) prop_get(ht, "position")
 #' @rdname position
 #' @export
 set_position <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(all(na.omit(value) %in% c("left", "center", "centre", "right", "wrapleft", "wrapright")))
-  }
+  assert_not_all_na(value,
+    all(na.omit(value) %in% c("left", "center", "centre", "right", "wrapleft", "wrapright"))
+  )
   value[value == "centre"] <- "center"
   prop_set_table(ht, value, "position")
 }
@@ -68,12 +68,12 @@ caption_pos <- function(ht) prop_get(ht, "caption_pos")
 #' @rdname caption_pos
 #' @export
 `caption_pos<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(all(na.omit(value) %in% c(
+  assert_not_all_na(value,
+    all(na.omit(value) %in% c(
       "top", "bottom", "topleft", "topcenter", "topcentre",
       "topright", "bottomleft", "bottomcenter", "bottomcentre", "bottomright"
-    )))
-  }
+    ))
+  )
   value[value == "topcentre"] <- "topcenter"
   value[value == "bottomcentre"] <- "bottomcenter"
   prop_replace(ht, value, "caption_pos")
@@ -82,12 +82,12 @@ caption_pos <- function(ht) prop_get(ht, "caption_pos")
 #' @rdname caption_pos
 #' @export
 set_caption_pos <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(all(na.omit(value) %in% c(
+  assert_not_all_na(value,
+    all(na.omit(value) %in% c(
       "top", "bottom", "topleft", "topcenter", "topcentre",
       "topright", "bottomleft", "bottomcenter", "bottomcentre", "bottomright"
-    )))
-  }
+    ))
+  )
   value[value == "topcentre"] <- "topcenter"
   value[value == "bottomcentre"] <- "bottomcenter"
   prop_set_table(ht, value, "caption_pos")
@@ -120,18 +120,14 @@ caption_width <- function(ht) prop_get(ht, "caption_width")
 #' @rdname caption_width
 #' @export
 `caption_width<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is_numeric_or_character(value))
-  }
+  assert_not_all_na(value, is_numeric_or_character(value))
   prop_replace(ht, value, "caption_width")
 }
 
 #' @rdname caption_width
 #' @export
 set_caption_width <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is_numeric_or_character(value))
-  }
+  assert_not_all_na(value, is_numeric_or_character(value))
   prop_set_table(ht, value, "caption_width")
 }
 
@@ -160,18 +156,14 @@ width <- function(ht) prop_get(ht, "width")
 #' @rdname width
 #' @export
 `width<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is_numeric_or_character(value))
-  }
+  assert_not_all_na(value, is_numeric_or_character(value))
   prop_replace(ht, value, "width")
 }
 
 #' @rdname width
 #' @export
 set_width <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is_numeric_or_character(value))
-  }
+  assert_not_all_na(value, is_numeric_or_character(value))
   prop_set_table(ht, value, "width")
 }
 
@@ -201,18 +193,14 @@ height <- function(ht) prop_get(ht, "height")
 #' @rdname height
 #' @export
 `height<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is_numeric_or_character(value))
-  }
+  assert_not_all_na(value, is_numeric_or_character(value))
   prop_replace(ht, value, "height")
 }
 
 #' @rdname height
 #' @export
 set_height <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is_numeric_or_character(value))
-  }
+  assert_not_all_na(value, is_numeric_or_character(value))
   prop_set_table(ht, value, "height")
 }
 
@@ -248,18 +236,14 @@ caption <- function(ht) prop_get(ht, "caption")
 #' @rdname caption
 #' @export
 `caption<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.string(value))
-  }
+  assert_not_all_na(value, is.string(value))
   prop_replace(ht, value, "caption")
 }
 
 #' @rdname caption
 #' @export
 set_caption <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.string(value))
-  }
+  assert_not_all_na(value, is.string(value))
   prop_set_table(ht, value, "caption")
 }
 
@@ -288,18 +272,14 @@ tabular_environment <- function(ht) prop_get(ht, "tabular_environment")
 #' @rdname tabular_environment
 #' @export
 `tabular_environment<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.string(value))
-  }
+  assert_not_all_na(value, is.string(value))
   prop_replace(ht, value, "tabular_environment")
 }
 
 #' @rdname tabular_environment
 #' @export
 set_tabular_environment <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.string(value))
-  }
+  assert_not_all_na(value, is.string(value))
   prop_set_table(ht, value, "tabular_environment")
 }
 
@@ -332,18 +312,14 @@ table_environment <- function(ht) prop_get(ht, "table_environment")
 #' @rdname table_environment
 #' @export
 `table_environment<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.string(value))
-  }
+  assert_not_all_na(value, is.string(value))
   prop_replace(ht, value, "table_environment")
 }
 
 #' @rdname table_environment
 #' @export
 set_table_environment <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.string(value))
-  }
+  assert_not_all_na(value, is.string(value))
   prop_set_table(ht, value, "table_environment")
 }
 
@@ -383,18 +359,14 @@ label <- function(ht) prop_get(ht, "label")
 #' @rdname label
 #' @export
 `label<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.string(value))
-  }
+  assert_not_all_na(value, is.string(value))
   prop_replace(ht, value, "label")
 }
 
 #' @rdname label
 #' @export
 set_label <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.string(value))
-  }
+  assert_not_all_na(value, is.string(value))
   prop_set_table(ht, value, "label")
 }
 
@@ -427,17 +399,13 @@ latex_float <- function(ht) prop_get(ht, "latex_float")
 #' @rdname latex_float
 #' @export
 `latex_float<-` <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.string(value))
-  }
+  assert_not_all_na(value, is.string(value))
   prop_replace(ht, value, "latex_float")
 }
 
 #' @rdname latex_float
 #' @export
 set_latex_float <- function(ht, value) {
-  if (!all(is.na(value))) {
-    assert_that(is.string(value))
-  }
+  assert_not_all_na(value, is.string(value))
   prop_set_table(ht, value, "latex_float")
 }

--- a/R/properties-table.R
+++ b/R/properties-table.R
@@ -25,23 +25,21 @@ position <- function(ht) prop_get(ht, "position")
 #' @rdname position
 #' @export
 `position<-` <- function(ht, value) {
-  prop_replace(ht, value, "position",
-    check_values = c("left", "center", "centre", "right", "wrapleft", "wrapright"),
-    extra = quote({
-      value[value == "centre"] <- "center"
-    })
-  )
+  if (!all(is.na(value))) {
+    assert_that(all(na.omit(value) %in% c("left", "center", "centre", "right", "wrapleft", "wrapright")))
+  }
+  value[value == "centre"] <- "center"
+  prop_replace(ht, value, "position")
 }
 
 #' @rdname position
 #' @export
 set_position <- function(ht, value) {
-  prop_set_table(ht, value, "position",
-    check_values = c("left", "center", "centre", "right", "wrapleft", "wrapright"),
-    extra = quote({
-      value[value == "centre"] <- "center"
-    })
-  )
+  if (!all(is.na(value))) {
+    assert_that(all(na.omit(value) %in% c("left", "center", "centre", "right", "wrapleft", "wrapright")))
+  }
+  value[value == "centre"] <- "center"
+  prop_set_table(ht, value, "position")
 }
 
 
@@ -70,31 +68,29 @@ caption_pos <- function(ht) prop_get(ht, "caption_pos")
 #' @rdname caption_pos
 #' @export
 `caption_pos<-` <- function(ht, value) {
-  prop_replace(ht, value, "caption_pos",
-    check_values = c(
+  if (!all(is.na(value))) {
+    assert_that(all(na.omit(value) %in% c(
       "top", "bottom", "topleft", "topcenter", "topcentre",
       "topright", "bottomleft", "bottomcenter", "bottomcentre", "bottomright"
-    ),
-    extra = quote({
-      value[value == "topcentre"] <- "topcenter"
-      value[value == "bottomcentre"] <- "bottomcenter"
-    })
-  )
+    )))
+  }
+  value[value == "topcentre"] <- "topcenter"
+  value[value == "bottomcentre"] <- "bottomcenter"
+  prop_replace(ht, value, "caption_pos")
 }
 
 #' @rdname caption_pos
 #' @export
 set_caption_pos <- function(ht, value) {
-  prop_set_table(ht, value, "caption_pos",
-    check_values = c(
+  if (!all(is.na(value))) {
+    assert_that(all(na.omit(value) %in% c(
       "top", "bottom", "topleft", "topcenter", "topcentre",
       "topright", "bottomleft", "bottomcenter", "bottomcentre", "bottomright"
-    ),
-    extra = quote({
-      value[value == "topcentre"] <- "topcenter"
-      value[value == "bottomcentre"] <- "bottomcenter"
-    })
-  )
+    )))
+  }
+  value[value == "topcentre"] <- "topcenter"
+  value[value == "bottomcentre"] <- "bottomcenter"
+  prop_set_table(ht, value, "caption_pos")
 }
 
 
@@ -124,13 +120,19 @@ caption_width <- function(ht) prop_get(ht, "caption_width")
 #' @rdname caption_width
 #' @export
 `caption_width<-` <- function(ht, value) {
-  prop_replace(ht, value, "caption_width", check_fun = is_numeric_or_character)
+  if (!all(is.na(value))) {
+    assert_that(is_numeric_or_character(value))
+  }
+  prop_replace(ht, value, "caption_width")
 }
 
 #' @rdname caption_width
 #' @export
 set_caption_width <- function(ht, value) {
-  prop_set_table(ht, value, "caption_width", check_fun = is_numeric_or_character)
+  if (!all(is.na(value))) {
+    assert_that(is_numeric_or_character(value))
+  }
+  prop_set_table(ht, value, "caption_width")
 }
 
 
@@ -158,13 +160,19 @@ width <- function(ht) prop_get(ht, "width")
 #' @rdname width
 #' @export
 `width<-` <- function(ht, value) {
-  prop_replace(ht, value, "width", check_fun = is_numeric_or_character)
+  if (!all(is.na(value))) {
+    assert_that(is_numeric_or_character(value))
+  }
+  prop_replace(ht, value, "width")
 }
 
 #' @rdname width
 #' @export
 set_width <- function(ht, value) {
-  prop_set_table(ht, value, "width", check_fun = is_numeric_or_character)
+  if (!all(is.na(value))) {
+    assert_that(is_numeric_or_character(value))
+  }
+  prop_set_table(ht, value, "width")
 }
 
 
@@ -193,13 +201,19 @@ height <- function(ht) prop_get(ht, "height")
 #' @rdname height
 #' @export
 `height<-` <- function(ht, value) {
-  prop_replace(ht, value, "height", check_fun = is_numeric_or_character)
+  if (!all(is.na(value))) {
+    assert_that(is_numeric_or_character(value))
+  }
+  prop_replace(ht, value, "height")
 }
 
 #' @rdname height
 #' @export
 set_height <- function(ht, value) {
-  prop_set_table(ht, value, "height", check_fun = is_numeric_or_character)
+  if (!all(is.na(value))) {
+    assert_that(is_numeric_or_character(value))
+  }
+  prop_set_table(ht, value, "height")
 }
 
 
@@ -234,13 +248,19 @@ caption <- function(ht) prop_get(ht, "caption")
 #' @rdname caption
 #' @export
 `caption<-` <- function(ht, value) {
-  prop_replace(ht, value, "caption", check_fun = is.string)
+  if (!all(is.na(value))) {
+    assert_that(is.string(value))
+  }
+  prop_replace(ht, value, "caption")
 }
 
 #' @rdname caption
 #' @export
 set_caption <- function(ht, value) {
-  prop_set_table(ht, value, "caption", check_fun = is.string)
+  if (!all(is.na(value))) {
+    assert_that(is.string(value))
+  }
+  prop_set_table(ht, value, "caption")
 }
 
 
@@ -268,13 +288,19 @@ tabular_environment <- function(ht) prop_get(ht, "tabular_environment")
 #' @rdname tabular_environment
 #' @export
 `tabular_environment<-` <- function(ht, value) {
-  prop_replace(ht, value, "tabular_environment", check_fun = is.string)
+  if (!all(is.na(value))) {
+    assert_that(is.string(value))
+  }
+  prop_replace(ht, value, "tabular_environment")
 }
 
 #' @rdname tabular_environment
 #' @export
 set_tabular_environment <- function(ht, value) {
-  prop_set_table(ht, value, "tabular_environment", check_fun = is.string)
+  if (!all(is.na(value))) {
+    assert_that(is.string(value))
+  }
+  prop_set_table(ht, value, "tabular_environment")
 }
 
 
@@ -306,13 +332,19 @@ table_environment <- function(ht) prop_get(ht, "table_environment")
 #' @rdname table_environment
 #' @export
 `table_environment<-` <- function(ht, value) {
-  prop_replace(ht, value, "table_environment", check_fun = is.string)
+  if (!all(is.na(value))) {
+    assert_that(is.string(value))
+  }
+  prop_replace(ht, value, "table_environment")
 }
 
 #' @rdname table_environment
 #' @export
 set_table_environment <- function(ht, value) {
-  prop_set_table(ht, value, "table_environment", check_fun = is.string)
+  if (!all(is.na(value))) {
+    assert_that(is.string(value))
+  }
+  prop_set_table(ht, value, "table_environment")
 }
 
 
@@ -351,13 +383,19 @@ label <- function(ht) prop_get(ht, "label")
 #' @rdname label
 #' @export
 `label<-` <- function(ht, value) {
-  prop_replace(ht, value, "label", check_fun = is.string)
+  if (!all(is.na(value))) {
+    assert_that(is.string(value))
+  }
+  prop_replace(ht, value, "label")
 }
 
 #' @rdname label
 #' @export
 set_label <- function(ht, value) {
-  prop_set_table(ht, value, "label", check_fun = is.string)
+  if (!all(is.na(value))) {
+    assert_that(is.string(value))
+  }
+  prop_set_table(ht, value, "label")
 }
 
 
@@ -389,11 +427,17 @@ latex_float <- function(ht) prop_get(ht, "latex_float")
 #' @rdname latex_float
 #' @export
 `latex_float<-` <- function(ht, value) {
-  prop_replace(ht, value, "latex_float", check_fun = is.string)
+  if (!all(is.na(value))) {
+    assert_that(is.string(value))
+  }
+  prop_replace(ht, value, "latex_float")
 }
 
 #' @rdname latex_float
 #' @export
 set_latex_float <- function(ht, value) {
-  prop_set_table(ht, value, "latex_float", check_fun = is.string)
+  if (!all(is.na(value))) {
+    assert_that(is.string(value))
+  }
+  prop_set_table(ht, value, "latex_float")
 }

--- a/R/property-helpers.R
+++ b/R/property-helpers.R
@@ -93,45 +93,21 @@ prop_get <- function(ht, prop) {
   attr(ht, prop)
 }
 
-#' Validate and normalise property values
-#'
-#' @param value        Proposed property values.
-#' @param prop         Property name.
-#' @param check_fun    Optional validation function.
-#' @param check_values Optional vector of allowed values.
-#' @param reset_na     Should `NA` values be replaced with the huxtable default?
-#'
-#' @return Normalised `value`.
-#' @noRd
-validate_prop <- function(value, prop, check_fun = NULL, check_values = NULL,
-                           reset_na = TRUE) {
-  if (!all(is.na(value))) {
-    if (!is.null(check_fun)) stopifnot(check_fun(value))
-    if (!is.null(check_values)) {
-      stopifnot(all(na.omit(value) %in% check_values))
-    }
-  }
-  if (reset_na) {
-    value[is.na(value)] <- huxtable_env$huxtable_default_attrs[[prop]]
-  }
-  value
-}
-
 #' Replace an entire property matrix/vector
 #'
 #' @param ht           A huxtable.
 #' @param value        New property values.
 #' @param prop         Property name.
-#' @param check_fun    Optional validation function.
-#' @param check_values Optional vector of allowed values.
 #' @param extra        Extra code to run after validation.
-#' @param reset_na     Passed to [`validate_prop`].
+#' @param reset_na     Should `NA` values be replaced with the huxtable default?
 #' @param coerce_mode  If `TRUE`, coerce the stored matrix mode to match `value`.
 #'
 #' @noRd
-prop_replace <- function(ht, value, prop, check_fun = NULL, check_values = NULL,
-                          extra = NULL, reset_na = TRUE, coerce_mode = TRUE) {
-  value <- validate_prop(value, prop, check_fun, check_values, reset_na)
+prop_replace <- function(ht, value, prop, extra = NULL, reset_na = TRUE,
+                          coerce_mode = TRUE) {
+  if (reset_na) {
+    value[is.na(value)] <- huxtable_env$huxtable_default_attrs[[prop]]
+  }
   if (!is.null(extra)) eval(extra)
   attr(ht, prop)[] <- value
   if (coerce_mode) mode(attr(ht, prop)) <- mode(value)
@@ -144,14 +120,12 @@ prop_replace <- function(ht, value, prop, check_fun = NULL, check_values = NULL,
 #' @param row,col      Row/column specifiers.
 #' @param value        Property values.
 #' @param prop         Property name.
-#' @param check_fun    Optional validation function.
-#' @param check_values Optional vector of allowed values.
 #' @param extra        Extra code to run after validation.
-#' @param reset_na     Passed to [`validate_prop`].
+#' @param reset_na     Should `NA` values be replaced with the huxtable default?
 #'
 #' @noRd
-prop_set <- function(ht, row, col, value, prop, check_fun = NULL,
-                      check_values = NULL, extra = NULL, reset_na = TRUE) {
+prop_set <- function(ht, row, col, value, prop, extra = NULL,
+                      reset_na = TRUE) {
   assert_that(is_huxtable(ht))
   if (missing(col) && missing(value)) {
     value <- row
@@ -164,7 +138,9 @@ prop_set <- function(ht, row, col, value, prop, check_fun = NULL,
   rc <- list()
   rc$row <- get_rc_spec(ht, row, 1)
   rc$col <- get_rc_spec(ht, col, 2)
-  value <- validate_prop(value, prop, check_fun, check_values, reset_na)
+  if (reset_na) {
+    value[is.na(value)] <- huxtable_env$huxtable_default_attrs[[prop]]
+  }
   if (!is.null(extra)) eval(extra)
   attr(ht, prop)[rc$row, rc$col] <- value
   ht
@@ -175,9 +151,10 @@ prop_set <- function(ht, row, col, value, prop, check_fun = NULL,
 #' @param fn A mapping function. See [mapping-functions].
 #' @inheritParams prop_set
 #'
+#' @param reset_na     Should `NA` values be replaced with the huxtable default?
 #' @noRd
-prop_map <- function(ht, row, col, fn, prop, check_fun = NULL,
-                      check_values = NULL, extra = NULL, reset_na = TRUE) {
+prop_map <- function(ht, row, col, fn, prop, extra = NULL,
+                      reset_na = TRUE) {
   assert_that(is_huxtable(ht))
   if (missing(col) && missing(fn)) {
     fn <- row
@@ -193,7 +170,9 @@ prop_map <- function(ht, row, col, fn, prop, check_fun = NULL,
   current <- attr(ht, prop)[rc$row, rc$col, drop = FALSE]
   if (is_huxtable(current)) current <- as.matrix(current)
   value <- fn(ht, rc$row, rc$col, current)
-  value <- validate_prop(value, prop, check_fun, check_values, reset_na)
+  if (reset_na) {
+    value[is.na(value)] <- huxtable_env$huxtable_default_attrs[[prop]]
+  }
   if (!is.null(extra)) eval(extra)
   attr(ht, prop)[rc$row, rc$col] <- value
   ht
@@ -202,16 +181,20 @@ prop_map <- function(ht, row, col, fn, prop, check_fun = NULL,
 #' Set values for a row-based property
 #'
 #' @inheritParams prop_set
+#'
+#' @param reset_na     Should `NA` values be replaced with the huxtable default?
 #' @noRd
-prop_set_row <- function(ht, row, value, prop, check_fun = NULL,
-                          check_values = NULL, extra = NULL, reset_na = TRUE) {
+prop_set_row <- function(ht, row, value, prop, extra = NULL,
+                          reset_na = TRUE) {
   assert_that(is_huxtable(ht))
   if (missing(value)) {
     value <- row
     row <- seq_len(nrow(ht))
   }
   row <- get_rc_spec(ht, row, 1)
-  value <- validate_prop(value, prop, check_fun, check_values, reset_na)
+  if (reset_na) {
+    value[is.na(value)] <- huxtable_env$huxtable_default_attrs[[prop]]
+  }
   if (!is.null(extra)) eval(extra)
   attr(ht, prop)[row] <- value
   ht
@@ -220,16 +203,20 @@ prop_set_row <- function(ht, row, value, prop, check_fun = NULL,
 #' Set values for a column-based property
 #'
 #' @inheritParams prop_set
+#'
+#' @param reset_na     Should `NA` values be replaced with the huxtable default?
 #' @noRd
-prop_set_col <- function(ht, col, value, prop, check_fun = NULL,
-                          check_values = NULL, extra = NULL, reset_na = TRUE) {
+prop_set_col <- function(ht, col, value, prop, extra = NULL,
+                          reset_na = TRUE) {
   assert_that(is_huxtable(ht))
   if (missing(value)) {
     value <- col
     col <- seq_len(ncol(ht))
   }
   col <- get_rc_spec(ht, col, 2)
-  value <- validate_prop(value, prop, check_fun, check_values, reset_na)
+  if (reset_na) {
+    value[is.na(value)] <- huxtable_env$huxtable_default_attrs[[prop]]
+  }
   if (!is.null(extra)) eval(extra)
   attr(ht, prop)[col] <- value
   ht
@@ -238,11 +225,15 @@ prop_set_col <- function(ht, col, value, prop, check_fun = NULL,
 #' Set a table-level property
 #'
 #' @inheritParams prop_set
+#'
+#' @param reset_na     Should `NA` values be replaced with the huxtable default?
 #' @noRd
-prop_set_table <- function(ht, value, prop, check_fun = NULL,
-                            check_values = NULL, extra = NULL, reset_na = TRUE) {
+prop_set_table <- function(ht, value, prop, extra = NULL,
+                            reset_na = TRUE) {
   assert_that(is_huxtable(ht))
-  value <- validate_prop(value, prop, check_fun, check_values, reset_na)
+  if (reset_na) {
+    value[is.na(value)] <- huxtable_env$huxtable_default_attrs[[prop]]
+  }
   if (!is.null(extra)) eval(extra)
   attr(ht, prop) <- value
   ht

--- a/R/row-col-fns.R
+++ b/R/row-col-fns.R
@@ -156,17 +156,20 @@ final <- function(n = 1) {
 NULL
 
 
-get_rc_spec <- function(ht, obj, dimno) {
+get_rc_spec <- function(ht, obj, dimno, env = parent.frame()) {
   dim_length <- dim(ht)[dimno]
   if (missing(obj)) {
     return(seq_len(dim_length))
   }
 
-  # You can"t evaluate obj before running the tidyselect; otherwise functions like starts_with throw an error.
   result <- if (dimno == 2) {
-    tidyselect::with_vars(colnames(ht), if (is.function(obj)) obj(ht, dimno) else obj)
+    tidyselect::with_vars(colnames(ht), {
+      val <- if (is.language(obj) || is.symbol(obj) || is.expression(obj)) eval(obj, env) else obj
+      if (is.function(val)) val(ht, dimno) else val
+    })
   } else {
-    if (is.function(obj)) obj(ht, dimno) else obj
+    val <- if (is.language(obj) || is.symbol(obj) || is.expression(obj)) eval(obj, env) else obj
+    if (is.function(val)) val(ht, dimno) else val
   }
 
   result


### PR DESCRIPTION
## Summary
- inline value validation inside each property setter and remove `check_fun`/`check_values` plumbing
- update border helpers to validate inputs directly and support missing arguments
- switch property validation from `stopifnot` to `assert_that`

## Testing
- `devtools::document()` *(fails: no package called 'openxlsx', 'dplyr', 'flextable', 'lmtest', etc.)*
- `devtools::test(filter = "^(?!.*fuzz)", perl = TRUE)` *(fails: LaTeX toolchain missing, tlmgr not found, pdflatex unavailable, and other dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_68971133aaec8330871adcb6c3019a66