### PR TITLE
bugfix: prevent duplicate rows in print_html output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Added Typst export via `to_typst()` and `print_typst()`.
 * Added `as_html()` for obtaining table as `htmltools` tags.
 * `to_screen()` now displays double, dashed and dotted border styles.
+* Bugfix: `print_html()` duplicated table rows for simple huxtables.
 
 
 # huxtable 5.6.0

--- a/R/html.R
+++ b/R/html.R
@@ -293,7 +293,6 @@ build_row_html <- function(ht, cells_html) {
     cells_html <- paste0(row_html, collapse = "")
   }
 
-  cells_html <- paste0(tr, cells_html, rep("</tr>\n", length(tr)))
   paste0(cells_html, collapse = "")
 }
 

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -26,6 +26,7 @@ of long inline styles.
 \item Added Typst export via \code{to_typst()} and \code{print_typst()}.
 \item Added \code{as_html()} for obtaining table as \code{htmltools} tags.
 \item \code{to_screen()} now displays double, dashed and dotted border styles.
+\item Bugfix: \code{print_html()} duplicated table rows for simple huxtables.
 }
 }
 }

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -204,6 +204,15 @@ test_that("output works with 1x1 huxtables", {
 })
 
 
+test_that("Bugfix: print_html doesn't duplicate rows", {
+  html <- to_html(hux(letters[1:2]))
+  tbody_count <- length(regmatches(html, gregexpr("<tbody>", html, fixed = TRUE))[[1]])
+  td_count <- length(regmatches(html, gregexpr("<td", html, fixed = TRUE))[[1]])
+  expect_identical(tbody_count, 1L)
+  expect_identical(td_count, 2L)
+})
+
+
 test_that("format.huxtable works", {
   ht <- hux(a = 1:3, b = 1:3)
   for (output in c("latex", "html", "md", "screen", "typst")) {


### PR DESCRIPTION
## Summary
- fix `build_row_html` so HTML tables don't duplicate rows
- test that `print_html` outputs each row once
- note the fix in NEWS

## Testing
- `devtools::test(filter = 'print')`


------
https://chatgpt.com/codex/tasks/task_e_6897a322ee688330b842fbf3b755b161