### PR TITLE
bugfix: avoid invalid typst stroke for solid borders

### DIFF
--- a/R/typst.R
+++ b/R/typst.R
@@ -251,11 +251,25 @@ typst_stroke <- function(ht, row, col) {
   bbc <- format_color(bottom_border_color(ht)[row, col], default = "black")
   lbc <- format_color(left_border_color(ht)[row, col], default = "black")
 
+  stroke_side <- function(thickness, style, color) {
+    if (is.na(style) || style == "solid") {
+      sprintf("stroke(thickness: %.4gpt, paint: rgb(%s))", thickness, color)
+    } else {
+      dash_styles <- c(dashed = "dashed", dotted = "dotted")
+      dash <- dash_styles[style]
+      if (is.na(dash)) {
+        sprintf("stroke(thickness: %.4gpt, paint: rgb(%s))", thickness, color)
+      } else {
+        sprintf("stroke(thickness: %.4gpt, paint: rgb(%s), dash: \"%s\")", thickness, color, dash)
+      }
+    }
+  }
+
   stroke_parts <- c()
-  if (tb > 0) stroke_parts <- c(stroke_parts, sprintf("top: %.4gpt + %s + rgb(%s)", tb, tbs, tbc))
-  if (rb > 0) stroke_parts <- c(stroke_parts, sprintf("right: %.4gpt + %s + rgb(%s)", rb, rbs, rbc))
-  if (bb > 0) stroke_parts <- c(stroke_parts, sprintf("bottom: %.4gpt + %s + rgb(%s)", bb, bbs, bbc))
-  if (lb > 0) stroke_parts <- c(stroke_parts, sprintf("left: %.4gpt + %s + rgb(%s)", lb, lbs, lbc))
+  if (tb > 0) stroke_parts <- c(stroke_parts, sprintf("top: %s", stroke_side(tb, tbs, tbc)))
+  if (rb > 0) stroke_parts <- c(stroke_parts, sprintf("right: %s", stroke_side(rb, rbs, rbc)))
+  if (bb > 0) stroke_parts <- c(stroke_parts, sprintf("bottom: %s", stroke_side(bb, bbs, bbc)))
+  if (lb > 0) stroke_parts <- c(stroke_parts, sprintf("left: %s", stroke_side(lb, lbs, lbc)))
 
   if (length(stroke_parts) > 0) {
     sprintf("stroke: (%s)", paste(stroke_parts, collapse = ", "))

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -58,12 +58,25 @@ test_that("to_typst maps properties", {
   expect_match(res, "rowspan: 2")
   expect_match(res, "align: (right + top)", fixed = TRUE)
   expect_match(res, "fill: rgb")
-  expect_match(res, "stroke: \\(top: 1pt \\+ solid \\+ rgb")
+  expect_match(
+    res,
+    "stroke: \\(top: stroke\\(thickness: 1pt, paint: rgb\\(0, 0, 255\\)\\)\\)"
+  )
   expect_match(
     res,
     "text\\(weight: \"bold\", style: \"italic\", size: 12pt, family: \"Courier\", fill: rgb\\(0, 0, 255\\)\\)\\[1\\]"
   )
   expect_match(res, "inset: \\(top: 3pt, right: 2pt, bottom: 4pt, left: 1pt\\)")
+})
+
+test_that("Bugfix: solid border generates valid typst", {
+  ht <- hux(a = 1:2, b = 3:4)
+  ht <- set_top_border(ht, 1, 1)
+  res <- to_typst(ht)
+  expect_match(
+    res,
+    "stroke: \\(top: stroke\\(thickness: 0.4pt, paint: rgb\\(0, 0, 0\\)\\)\\)"
+  )
 })
 
 test_that("print_typst outputs to stdout", {


### PR DESCRIPTION
## Summary
- ensure typst output uses `stroke()` and omits unsupported `solid` token
- add regression test for solid border generation

## Testing
- `devtools::test(filter="typst")`


------
https://chatgpt.com/codex/tasks/task_e_6897bced9ac88330a76214f453690c8d