### PR TITLE
Bugfix: omit Typst borders by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
   long inline styles.
 * Added `as_html()` for obtaining table as `htmltools` tags.
 * `to_screen()` now displays double, dashed and dotted border styles.
+* Bugfix: Typst output now omits borders when none are set.
 
 
 # huxtable 5.6.0

--- a/R/typst.R
+++ b/R/typst.R
@@ -117,6 +117,8 @@ typst_table_options <- function(ht, col_w_str) {
     table_opts <- c(table_opts, sprintf("align: %s", align))
   }
 
+  table_opts <- c(table_opts, "stroke: none")
+
   table_opts
 }
 

--- a/agent-notes.md
+++ b/agent-notes.md
@@ -9,3 +9,7 @@
 your referring to.
 
 * Where possible, update an existing note before adding your own.
+
+## Notes
+
+* Typst export sets `stroke: none` on tables to avoid default borders. 86529fa

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -79,6 +79,14 @@ test_that("Bugfix: solid border generates valid typst", {
   )
 })
 
+test_that("Bugfix: typst tables without borders have no stroke", {
+  ht <- hux(a = 1:2, b = 3:4, add_colnames = FALSE)
+  valign(ht) <- NA
+  res <- to_typst(ht)
+  expect_match(res, "stroke: none", fixed = TRUE)
+  expect_false(grepl("stroke\\(", res))
+})
+
 test_that("print_typst outputs to stdout", {
   ht <- hux(a = 1)
   expect_output(print_typst(ht), "#figure", fixed = TRUE)


### PR DESCRIPTION
## Summary
- Explicitly set `stroke: none` on Typst tables so default borders are suppressed when no huxtable borders are set
- Add regression test confirming Typst tables without borders have no stroke
- Document the bugfix in NEWS

## Testing
- `devtools::test(filter = 'typst')`


------
https://chatgpt.com/codex/tasks/task_e_6897c4e218588330a3487e57c0cb5422