### PR TITLE
bugfix: handle typst merge cell blank rows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
   long inline styles.
 * Added `as_html()` for obtaining table as `htmltools` tags.
 * `to_screen()` now displays double, dashed and dotted border styles.
+* Bugfix: merged cells no longer produce empty rows in Typst export.
 
 
 # huxtable 5.6.0

--- a/R/typst.R
+++ b/R/typst.R
@@ -64,22 +64,29 @@ to_typst <- function(ht, ...) {
   header_block <- ""
   if (any(hr)) {
     header_rows_strings <- row_strings[hr]
-    header_block <- paste0(
-      "  table.header(\n",
-      paste0("    ", header_rows_strings, collapse = "\n"),
-      "\n  ),\n"
-    )
+    header_rows_strings <- header_rows_strings[nzchar(header_rows_strings)]
+    if (length(header_rows_strings) > 0) {
+      header_block <- paste0(
+        "  table.header(\n",
+        paste0("    ", header_rows_strings, collapse = "\n"),
+        "\n  ),\n"
+      )
+    }
     row_strings <- row_strings[!hr]
   }
+  row_strings <- row_strings[nzchar(row_strings)]
 
   header_cols_block <- ""
   if (any(hc)) {
     col_strings <- apply(cells[, hc, drop = FALSE], 1, function(x) paste(x[x != ""], collapse = " "))
-    header_cols_block <- paste0(
-      "  table.header(columns: (", paste(hc, collapse = ", "), "))[\n",
-      paste0("    ", col_strings, collapse = "\n"),
-      "\n  ]\n"
-    )
+    col_strings <- col_strings[nzchar(col_strings)]
+    if (length(col_strings) > 0) {
+      header_cols_block <- paste0(
+        "  table.header(columns: (", paste(hc, collapse = ", "), "))[\n",
+        paste0("    ", col_strings, collapse = "\n"),
+        "\n  ]\n"
+      )
+    }
   }
 
   result <- paste0(
@@ -89,7 +96,6 @@ to_typst <- function(ht, ...) {
     paste0("  ", row_strings, collapse = ",\n"),
     "\n)"
   )
-
   result <- typst_figure(ht, result)
 
   if (using_quarto()) {

--- a/agent-notes.md
+++ b/agent-notes.md
@@ -9,3 +9,7 @@
 your referring to.
 
 * Where possible, update an existing note before adding your own.
+
+## Typst export
+
+* `to_typst()` builds cell strings row-by-row and previously left empty rows when all cells were shadowed by merges. Filter `row_strings` and `header_rows_strings` with `nzchar()` before assembling the table to avoid stray commas. rev b07e9e37.

--- a/tests/testthat/test-quick-typst.R
+++ b/tests/testthat/test-quick-typst.R
@@ -22,3 +22,4 @@ test_that("quick_typst_pdf works", {
   expect_silent(quick_typst_pdf(m, dfr, ht, file = tf, open = FALSE))
   expect_true(file.exists(tf))
 })
+

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -79,6 +79,13 @@ test_that("Bugfix: solid border generates valid typst", {
   )
 })
 
+test_that("Bugfix: merge_cells in Typst output produces no empty rows", {
+  ht <- merge_cells(jams, 1:2, 1:2)
+  typ <- to_typst(ht)
+  lines <- strsplit(typ, "\n")[[1]]
+  expect_false(any(trimws(lines) == ","))
+})
+
 test_that("print_typst outputs to stdout", {
   ht <- hux(a = 1)
   expect_output(print_typst(ht), "#figure", fixed = TRUE)


### PR DESCRIPTION
## Summary
- prevent empty rows when merged cells are exported to Typst
- test Typst export with merged cells using to_typst
- document Typst merged cell fix in NEWS

## Testing
- `devtools::load_all(); devtools::test(filter = "typst", stop_on_failure = TRUE)`

------
https://chatgpt.com/codex/tasks/task_e_68980a971f3883309fee413e766f40a1