### PR TITLE
bugfix: escape typst caption chars

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * Added `as_html()` for obtaining table as `htmltools` tags.
 * `to_screen()` now displays double, dashed and dotted border styles.
 * Bugfix: Typst output now omits borders when none are set.
+* Bugfix: Typst captions now escape special characters.
 
 
 # huxtable 5.6.0

--- a/R/typst.R
+++ b/R/typst.R
@@ -101,6 +101,20 @@ to_typst <- function(ht, ...) {
 
 # helpers -----------------------------------------------------------------------
 
+#' Escape special characters for Typst markup
+#'
+#' @param x A character string.
+#'
+#' @return Escaped string safe for Typst.
+#' @noRd
+typst_escape <- function(x) {
+  x <- gsub("\\\\", "\\\\\\\\", x)
+  x <- gsub("#", "\\#", x, fixed = TRUE)
+  x <- gsub("[", "\\[", x, fixed = TRUE)
+  x <- gsub("]", "\\]", x, fixed = TRUE)
+  x
+}
+
 #' Build options for a Typst table
 #'
 #' @param ht A huxtable.
@@ -131,7 +145,7 @@ typst_figure <- function(ht, text) {
             "none"
           } else {
             lab <- make_label(ht)
-            cap <- caption(ht) # TODO what about labels?
+            cap <- typst_escape(caption(ht)) # TODO what about labels?
             paste0("[", cap, "]")
           }
 

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -87,6 +87,13 @@ test_that("Bugfix: typst tables without borders have no stroke", {
   expect_false(grepl("stroke\\(", res))
 })
 
+test_that("Bugfix: caption escapes special characters", {
+  ht <- hux(a = 1:2, b = 3:4)
+  caption(ht) <- "#notfun"
+  res <- to_typst(ht)
+  expect_match(res, "caption: \\[\\\\#notfun\\]")
+})
+
 test_that("print_typst outputs to stdout", {
   ht <- hux(a = 1)
   expect_output(print_typst(ht), "#figure", fixed = TRUE)


### PR DESCRIPTION
## Summary
- escape special characters in Typst captions to prevent compilation errors
- add regression test for caption escaping
- document caption escaping in NEWS

## Testing
- `devtools::test(filter="typst")`


------
https://chatgpt.com/codex/tasks/task_e_6897c6090bd08330a621cc8387ef627d