### PR TITLE
bugfix: use block for unwrap typst

### DIFF
--- a/R/typst.R
+++ b/R/typst.R
@@ -302,7 +302,7 @@ typst_cell_text <- function(ht, row, col, cell_text) {
   }
 
   if (!wrap(ht)[row, col]) {
-    text <- sprintf("#box(breakable: false)[%s]", text)
+    text <- sprintf("#block(breakable: false)[%s]", text)
   }
 
   text

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -96,9 +96,9 @@ test_that("to_typst respects wrap", {
   long <- strrep("a", 100)
   ht <- hux(a = long, add_colnames = FALSE)
   res_wrap <- to_typst(ht)
-  expect_false(grepl("box\\(breakable: false\\)", res_wrap))
+  expect_false(grepl("block\\(breakable: false\\)", res_wrap))
 
   wrap(ht) <- FALSE
   res_nowrap <- to_typst(ht)
-  expect_match(res_nowrap, paste0("box\\(breakable: false\\)\\[", long, "\\]"))
+  expect_match(res_nowrap, paste0("block\\(breakable: false\\)\\[", long, "\\]"))
 })


### PR DESCRIPTION
## Summary
- replace invalid `#box(breakable: false)` with `#block(breakable: false)` when wrapping is disabled
- add unit test verifying `to_typst` respects `wrap = FALSE` without running the slow `quick_typst_pdf` compilation

## Testing
- `devtools::test(filter = "typst")`


------
https://chatgpt.com/codex/tasks/task_e_68980bf30bf883309e6e113ee06b0576