### PR TITLE
feature: respect caption position and width in Typst

### DIFF
--- a/R/typst.R
+++ b/R/typst.R
@@ -151,13 +151,30 @@ typst_figure <- function(ht, text) {
             "none"
           } else {
             lab <- make_label(ht)
-            cap <- typst_escape(caption(ht)) # TODO what about labels?
-            paste0("[", cap, "]")
+            cap_text <- typst_escape(make_caption(ht, lab, "typst"))
+
+            cap_pos <- caption_pos(ht)
+            vpos <- if (grepl("top", cap_pos)) "top" else "bottom"
+            hpos <- get_caption_hpos(ht)
+
+            cap_body <- cap_text
+
+            cap_width <- caption_width(ht)
+            if (!is.na(cap_width)) {
+              if (is.numeric(cap_width)) {
+                cap_width <- paste0(cap_width * 100, "%")
+              }
+              cap_body <- sprintf("block(width: %s)[%s]", cap_width, cap_body)
+            }
+
+            cap_body <- sprintf("align(%s)[%s]", hpos, cap_body)
+
+            sprintf("figure.caption(position: %s, %s)", vpos, cap_body)
           }
 
   cap <- sprintf("caption: %s", cap)
 
-  # TODO: caption_pos, caption_width, position, numbering, label
+  # TODO: position, numbering, label
 
   fig <- paste0(
     "#figure(\n",

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -52,7 +52,11 @@ test_that("to_typst maps properties", {
 
   res <- to_typst(ht)
   expect_match(res, "#figure(", fixed = TRUE)
-  expect_match(res, "caption: \\[A cap\\]")
+  expect_match(
+    res,
+    "caption: figure.caption(position: top, align(center)[A cap])",
+    fixed = TRUE
+  )
   expect_match(res, "columns: \\(0.2fr, 0.3fr, 0.5fr\\)")
   expect_match(res, "colspan: 2")
   expect_match(res, "rowspan: 2")
@@ -98,7 +102,42 @@ test_that("Bugfix: caption escapes special characters", {
   ht <- hux(a = 1:2, b = 3:4)
   caption(ht) <- "#notfun"
   res <- to_typst(ht)
-  expect_match(res, "caption: \\[\\\\#notfun\\]")
+  expect_match(
+    res,
+    "caption: figure.caption(position: top, align(center)[\\#notfun])",
+    fixed = TRUE
+  )
+})
+
+test_that("caption position and width render in Typst", {
+  ht <- hux(a = 1:2, b = 3:4)
+  caption(ht) <- "A cap"
+  caption_pos(ht) <- "topleft"
+  caption_width(ht) <- 0.6
+  res <- to_typst(ht)
+  expect_match(
+    res,
+    "caption: figure.caption(position: top, align(left)[block(width: 60%)[A cap]])",
+    fixed = TRUE
+  )
+
+  caption_pos(ht) <- "bottomcenter"
+  caption_width(ht) <- NA
+  res <- to_typst(ht)
+  expect_match(
+    res,
+    "caption: figure.caption(position: bottom, align(center)[A cap])",
+    fixed = TRUE
+  )
+
+  caption_pos(ht) <- "topright"
+  caption_width(ht) <- "30pt"
+  res <- to_typst(ht)
+  expect_match(
+    res,
+    "caption: figure.caption(position: top, align(right)[block(width: 30pt)[A cap]])",
+    fixed = TRUE
+  )
 })
 
 test_that("print_typst outputs to stdout", {


### PR DESCRIPTION
## Summary
- support caption_pos and caption_width in typst_figure to control caption layout
- test caption position and width combinations in Typst output

## Testing
- `devtools::test(filter="typst", perl = TRUE)`

------
https://chatgpt.com/codex/tasks/task_e_689817b82d288330a284d4dbf8bfb4d7