### PR TITLE
Support labels in Typst output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
   body rows in `<tbody>` when header rows are at the top of the table.
 * Added Typst export via `to_typst()` and `print_typst()`. Quarto integration
   is available as well as `quick_typst()` and `quick_typst_pdf()` functions.
+* Typst export now supports `label()` for cross-referencing.
 * HTML output now uses CSS classes with a shared `<style>` block instead of
   long inline styles.
 * Added `as_html()` for obtaining table as `htmltools` tags.

--- a/R/typst.R
+++ b/R/typst.R
@@ -144,20 +144,23 @@ typst_table_options <- function(ht, col_w_str) {
 
 
 #' Surround text by a typst figure
-#'
+#' 
 #' @noRd
 typst_figure <- function(ht, text) {
-  cap <-  if (is.na(caption(ht))) {
-            "none"
-          } else {
-            lab <- make_label(ht)
-            cap <- typst_escape(caption(ht)) # TODO what about labels?
-            paste0("[", cap, "]")
-          }
+  lab <- make_label(ht)
+  cap <- make_caption(ht, lab, "typst")
+
+  if (is.na(cap)) {
+    cap <- "none"
+  } else {
+    cap <- typst_escape(cap)
+    cap <- paste0("[", cap, "]")
+  }
 
   cap <- sprintf("caption: %s", cap)
+  lab <- if (is.na(lab)) "" else paste0(" <", lab, ">")
 
-  # TODO: caption_pos, caption_width, position, numbering, label
+  # TODO: caption_pos, caption_width, position, numbering
 
   fig <- paste0(
     "#figure(\n",
@@ -165,7 +168,8 @@ typst_figure <- function(ht, text) {
     ",\n",
     cap,
     "\n",
-    ")"
+    ")",
+    lab
   )
 
   return(fig)

--- a/agent-notes.md
+++ b/agent-notes.md
@@ -14,3 +14,4 @@ your referring to.
 
 * `to_typst()` builds cell strings row-by-row and previously left empty rows when all cells were shadowed by merges. Filter `row_strings` and `header_rows_strings` with `nzchar()` before assembling the table to avoid stray commas. rev b07e9e37.
 * Typst export sets `stroke: none` on tables to avoid default borders. 86529fa
+* Typst export outputs labels using `<label>` after the `#figure` block for cross-referencing. rev 088f1fe0

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -101,6 +101,13 @@ test_that("Bugfix: caption escapes special characters", {
   expect_match(res, "caption: \\[\\\\#notfun\\]")
 })
 
+test_that("to_typst outputs labels", {
+  ht <- hux(a = 1:2, b = 3:4)
+  label(ht) <- "tab:test"
+  res <- to_typst(ht)
+  expect_match(res, "\\) <tab:test>")
+})
+
 test_that("print_typst outputs to stdout", {
   ht <- hux(a = 1)
   expect_output(print_typst(ht), "#figure", fixed = TRUE)


### PR DESCRIPTION
## Summary
- Add label support to Typst export, appending figure labels for cross-referencing.
- Test Typst label output and document feature in NEWS.
- Note Typst label implementation in agent notes.

## Testing
- `devtools::test(filter="typst")`


------
https://chatgpt.com/codex/tasks/task_e_68981bcbc0b483308bd80f463213a2d8