### PR TITLE
feature: handle width in Typst export

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
   is available as well as `quick_typst()` and `quick_typst_pdf()` functions.
 * HTML output now uses CSS classes with a shared `<style>` block instead of
   long inline styles.
+* Typst export now respects `width(ht)` and infers equal column widths when
+  `col_width` is unspecified.
 * Added `as_html()` for obtaining table as `htmltools` tags.
 * `to_screen()` now displays double, dashed and dotted border styles.
 

--- a/R/typst.R
+++ b/R/typst.R
@@ -30,15 +30,7 @@ to_typst <- function(ht, ...) {
 
   contents <- clean_contents(ht, output_type = "latex")
   shadow <- matrix(display_cells(ht)$shadowed, nrow(ht), ncol(ht))
-
-  col_w <- col_width(ht)
-  if (is.numeric(col_w)) {
-    col_w_str <- ifelse(is.na(col_w), "auto", paste0(col_w, "fr"))
-  } else {
-    col_w_str <- ifelse(is.na(col_w), "auto", col_w)
-  }
-
-  table_opts <- typst_table_options(ht, col_w_str)
+  table_opts <- typst_table_options(ht)
   table_start <- paste0("table(\n  ", paste(table_opts, collapse = ",\n  "), ",\n")
 
   cells <- matrix("", nrow(ht), ncol(ht))
@@ -96,6 +88,15 @@ to_typst <- function(ht, ...) {
     paste0("  ", row_strings, collapse = ",\n"),
     "\n)"
   )
+
+  w <- width(ht)
+  if (!is.na(w)) {
+    if (is.numeric(w)) {
+      w <- paste0(w * 100, "%")
+    }
+    result <- sprintf("block(width: %s)[%s]", w, result)
+  }
+
   result <- typst_figure(ht, result)
 
   if (using_quarto()) {
@@ -124,11 +125,22 @@ typst_escape <- function(x) {
 #' Build options for a Typst table
 #'
 #' @param ht A huxtable.
-#' @param col_w_str Character vector of column widths formatted for Typst.
 #'
 #' @return Character vector of table options to be passed to `#table`.
 #' @noRd
-typst_table_options <- function(ht, col_w_str) {
+typst_table_options <- function(ht) {
+  col_w <- col_width(ht)
+  if (is.numeric(col_w)) {
+    col_w_str <- ifelse(is.na(col_w), "auto", paste0(col_w, "fr"))
+  } else {
+    col_w_str <- ifelse(is.na(col_w), "auto", col_w)
+  }
+
+  w <- width(ht)
+  if (!is.na(w) && all(is.na(col_w))) {
+    col_w_str <- rep("1fr", ncol(ht))
+  }
+
   table_opts <- c(paste0("columns: (", paste(col_w_str, collapse = ", "), ")"))
 
   pos <- position(ht)

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -25,6 +25,8 @@ integration is available as well as \code{quick_typst()} and
 \code{quick_typst_pdf()} functions.
 \item HTML output now uses CSS classes with a shared \verb{<style>} block instead
 of long inline styles.
+\item Typst export now respects \code{width(ht)} and infers equal column widths
+when \code{col_width} is unspecified.
 \item Added \code{as_html()} for obtaining table as \code{htmltools} tags.
 \item \code{to_screen()} now displays double, dashed and dotted border styles.
 }

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -163,3 +163,20 @@ test_that("to_typst respects wrap", {
   res_nowrap <- to_typst(ht)
   expect_match(res_nowrap, paste0("block\\(breakable: false\\)\\[", long, "\\]"))
 })
+
+test_that("numeric width and col_width generate block and fractional columns", {
+  ht <- hux(a = 1:2, b = 3:4, add_colnames = FALSE)
+  width(ht) <- 0.5
+  col_width(ht) <- c(0.3, 0.7)
+  res <- to_typst(ht)
+  expect_match(res, "block\\(width: 50%\\)")
+  expect_match(res, "columns: (0.3fr, 0.7fr)", fixed = TRUE)
+})
+
+test_that("fixed width with unspecified col_width defaults to equal columns", {
+  ht <- hux(a = 1:2, b = 3:4, add_colnames = FALSE)
+  width(ht) <- "300pt"
+  res <- to_typst(ht)
+  expect_match(res, "block\\(width: 300pt\\)")
+  expect_match(res, "columns: (1fr, 1fr)", fixed = TRUE)
+})


### PR DESCRIPTION
## Summary
- respect `width(ht)` when generating Typst tables
- default to equal `1fr` columns when width is set but `col_width` is unspecified
- test table width handling and update news

## Testing
- `devtools::document()` *(errors due to missing packages)*
- `devtools::test(filter="typst")`


------
https://chatgpt.com/codex/tasks/task_e_68981c44ce2883308791929cd7b9c368