### PR TITLE
feature: support typst row heights

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
   long inline styles.
 * Typst export now respects `width(ht)` and infers equal column widths when
   `col_width` is unspecified.
+* Typst export now respects `height()` and `row_height()`.
 * Added `as_html()` for obtaining table as `htmltools` tags.
 * `to_screen()` now displays double, dashed and dotted border styles.
 

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -23,10 +23,12 @@ body rows in \verb{<tbody>} when header rows are at the top of the table.
 \item Added Typst export via \code{to_typst()} and \code{print_typst()}. Quarto
 integration is available as well as \code{quick_typst()} and
 \code{quick_typst_pdf()} functions.
+\item Typst export now supports \code{label()} for cross-referencing.
 \item HTML output now uses CSS classes with a shared \verb{<style>} block instead
 of long inline styles.
 \item Typst export now respects \code{width(ht)} and infers equal column widths
 when \code{col_width} is unspecified.
+\item Typst export now respects \code{height()} and \code{row_height()}.
 \item Added \code{as_html()} for obtaining table as \code{htmltools} tags.
 \item \code{to_screen()} now displays double, dashed and dotted border styles.
 }

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -187,3 +187,12 @@ test_that("fixed width with unspecified col_width defaults to equal columns", {
   expect_match(res, "block\\(width: 300pt\\)")
   expect_match(res, "columns: (1fr, 1fr)", fixed = TRUE)
 })
+
+test_that("height and row_height render in Typst", {
+  ht <- hux(a = 1:2, b = 3:4, add_colnames = FALSE)
+  height(ht) <- 0.4
+  row_height(ht) <- c(0.25, 0.75)
+  res <- to_typst(ht)
+  expect_match(res, "block\\(height: 40%\\)")
+  expect_match(res, "rows: (0.25fr, 0.75fr)", fixed = TRUE)
+})


### PR DESCRIPTION
## Summary
- support table `height()` and `row_height()` when rendering Typst output
- test Typst output for height and row height settings

## Testing
- `devtools::test(filter="typst")`
- `devtools::load_all("."); ht<-hux(a=1:2,b=3:4, add_colnames=FALSE); height(ht)<-0.4; row_height(ht)<-c(0.25,0.75); tf<-tempfile(fileext=".pdf"); quick_typst_pdf(ht,file=tf,open=FALSE); cat("exists:",file.exists(tf),"\n")`


------
https://chatgpt.com/codex/tasks/task_e_6898f93710d483308cd860aba2e03005