### PR TITLE
feature: add typst markdown translator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 * Typst export now respects `width(ht)` and infers equal column widths when
   `col_width` is unspecified.
 * Typst export now respects `height()` and `row_height()`.
+* Typst markdown cells now handle formatting like bold, italics, strikethrough,
+  inline code, links, images, headings, and lists.
 * Added `as_html()` for obtaining table as `htmltools` tags.
 * `to_screen()` now displays double, dashed and dotted border styles.
 

--- a/agent-notes.md
+++ b/agent-notes.md
@@ -15,3 +15,4 @@ your referring to.
 * `to_typst()` builds cell strings row-by-row and previously left empty rows when all cells were shadowed by merges. Filter `row_strings` and `header_rows_strings` with `nzchar()` before assembling the table to avoid stray commas. rev b07e9e37.
 * Typst export sets `stroke: none` on tables to avoid default borders. 86529fa
 * Typst export outputs labels using `<label>` after the `#figure` block for cross-referencing. rev 088f1fe0
+* MarkdownTypstTranslator handles bold, italic, links, images, headings, strikethrough, inline code, and lists via `render_markdown("...", "typst")`. rev 45b775da

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -29,6 +29,8 @@ of long inline styles.
 \item Typst export now respects \code{width(ht)} and infers equal column widths
 when \code{col_width} is unspecified.
 \item Typst export now respects \code{height()} and \code{row_height()}.
+\item Typst markdown cells now handle formatting like bold, italics,
+strikethrough, inline code, links, images, headings, and lists.
 \item Added \code{as_html()} for obtaining table as \code{htmltools} tags.
 \item \code{to_screen()} now displays double, dashed and dotted border styles.
 }

--- a/tests/testthat/test-typst-markdown.R
+++ b/tests/testthat/test-typst-markdown.R
@@ -1,0 +1,41 @@
+local_edition(2)
+
+test_that("typst markdown translator handles formatting", {
+  expect_equal(unname(huxtable:::render_markdown("**bold**", "typst")), "**bold**")
+  expect_equal(unname(huxtable:::render_markdown("*italic*", "typst")), "*italic*")
+  expect_equal(unname(huxtable:::render_markdown("~~strike~~", "typst")), "#strike[strike]")
+  expect_equal(unname(huxtable:::render_markdown("`code`", "typst")), "`code`")
+})
+
+test_that("typst markdown translator handles links and images", {
+  expect_equal(
+    unname(huxtable:::render_markdown("[link](https://example.com)", "typst")),
+    '#link("https://example.com")[link]'
+  )
+  expect_equal(
+    unname(huxtable:::render_markdown("![alt](https://example.com/img.png)", "typst")),
+    '#image("https://example.com/img.png", alt: "alt")'
+  )
+})
+
+test_that("typst markdown translator handles headings", {
+  expect_equal(
+    unname(huxtable:::render_markdown("# Heading", "typst")),
+    "= Heading"
+  )
+  expect_equal(
+    unname(huxtable:::render_markdown("### Subheading", "typst")),
+    "=== Subheading"
+  )
+})
+
+test_that("typst markdown translator handles lists", {
+  expect_equal(
+    unname(huxtable:::render_markdown("- one\n- two", "typst")),
+    "- one\n- two\n"
+  )
+  expect_equal(
+    unname(huxtable:::render_markdown("1. one\n2. two", "typst")),
+    "+ one\n+ two\n"
+  )
+})


### PR DESCRIPTION
## Summary
- extend `MarkdownTypstTranslator` to render typst strikethrough, inline code, and list items
- cover typst markdown strikethrough, inline code, and lists with tests and news entry

## Testing
- `devtools::test(filter = "typst-markdown")`
- `devtools::document()` *(fails: there is no package called 'openxlsx', 'dplyr', 'flextable', 'lmtest')*


------
https://chatgpt.com/codex/tasks/task_e_68996fb41ed08330a5ab8df6ae7a0c56