### PR TITLE
bugfix: typst markdown output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * Typst export now respects `height()` and `row_height()`.
 * Typst markdown cells now handle formatting like bold, italics, strikethrough,
   inline code, links, images, headings, and lists.
+* Bugfix: Typst markdown cells no longer output TeX commands.
 * Added `as_html()` for obtaining table as `htmltools` tags.
 * `to_screen()` now displays double, dashed and dotted border styles.
 

--- a/R/clean-contents.R
+++ b/R/clean-contents.R
@@ -10,7 +10,7 @@
 #' @noRd
 clean_contents <- function(
     ht,
-    output_type = c("latex", "html", "screen", "markdown", "word", "excel", "rtf"),
+    output_type = c("latex", "html", "screen", "markdown", "word", "excel", "rtf", "typst"),
     ...) {
   output_type <- match.arg(output_type)
   contents <- as.matrix(as.data.frame(ht))
@@ -87,9 +87,13 @@ render_markdown_matrix <- function(contents, ht, output_type) {
     column <- contents[, col]
     md_rows <- md[, col]
     column[md_rows] <- render_markdown(column[md_rows], output_type)
-    if (output_type %in% c("latex", "html", "rtf")) {
+    if (output_type %in% c("latex", "html", "rtf", "typst")) {
       to_esc <- esc[, col] & !md_rows
-      column[to_esc] <- sanitize(column[to_esc], output_type)
+      column[to_esc] <- if (output_type == "typst") {
+        typst_escape(column[to_esc])
+      } else {
+        sanitize(column[to_esc], output_type)
+      }
     }
     column
   }, character(nrow(contents)))

--- a/R/typst.R
+++ b/R/typst.R
@@ -28,7 +28,7 @@ to_typst <- function(ht, ...) {
     return("")
   }
 
-  contents <- clean_contents(ht, output_type = "latex")
+  contents <- clean_contents(ht, output_type = "typst")
   shadow <- matrix(display_cells(ht)$shadowed, nrow(ht), ncol(ht))
   table_opts <- typst_table_options(ht)
   table_start <- paste0("table(\n  ", paste(table_opts, collapse = ",\n  "), ",\n")

--- a/agent-notes.md
+++ b/agent-notes.md
@@ -16,3 +16,4 @@ your referring to.
 * Typst export sets `stroke: none` on tables to avoid default borders. 86529fa
 * Typst export outputs labels using `<label>` after the `#figure` block for cross-referencing. rev 088f1fe0
 * MarkdownTypstTranslator handles bold, italic, links, images, headings, strikethrough, inline code, and lists via `render_markdown("...", "typst")`. rev 45b775da
+* `to_typst()` now uses `clean_contents(..., output_type = "typst")` so markdown cells output Typst markup instead of TeX. rev d233e674

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -31,6 +31,7 @@ when \code{col_width} is unspecified.
 \item Typst export now respects \code{height()} and \code{row_height()}.
 \item Typst markdown cells now handle formatting like bold, italics,
 strikethrough, inline code, links, images, headings, and lists.
+\item Bugfix: Typst markdown cells no longer output TeX commands.
 \item Added \code{as_html()} for obtaining table as \code{htmltools} tags.
 \item \code{to_screen()} now displays double, dashed and dotted border styles.
 }

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -109,6 +109,14 @@ test_that("Bugfix: caption escapes special characters", {
   )
 })
 
+test_that("Bugfix: markdown in Typst renders Typst markup", {
+  ht <- hux("Some markdown with *italic* and **bold**.", add_colnames = FALSE)
+  ht <- set_markdown(ht, 1, 1)
+  res <- to_typst(ht)
+  expect_match(res, "\\*italic\\* and \\*\\*bold\\*\\*", perl = TRUE)
+  expect_false(grepl("\\\\emph|\\\\textbf", res))
+})
+
 test_that("caption position and width render in Typst", {
   ht <- hux(a = 1:2, b = 3:4)
   caption(ht) <- "A cap"


### PR DESCRIPTION
## Summary
- ensure typst export processes markdown as Typst instead of TeX
- escape non-markdown cells for Typst output
- test Typst markdown rendering

## Testing
- `devtools::document()` *(fails: missing packages)*
- `devtools::test(filter = "typst")`


------
https://chatgpt.com/codex/tasks/task_e_6899b66f3bf88330b428b5daec58584f