### PR TITLE
chore: run lint workflow on master

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- correct GitHub workflow so lint action runs for master branch

## Testing
- `devtools::test(filter='attributes', perl=TRUE)`

------
https://chatgpt.com/codex/tasks/task_e_689a0e658d9c833083e51a15c988e32e