### PR TITLE
Add Typst cell rotation support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
   body rows in `<tbody>` when header rows are at the top of the table.
 * Added Typst export via `to_typst()` and `print_typst()`. Quarto integration
   is available as well as `quick_typst()` and `quick_typst_pdf()` functions.
+* Typst output now supports cell rotation.
 * HTML output now uses CSS classes with a shared `<style>` block instead of
   long inline styles.
 * Added `as_html()` for obtaining table as `htmltools` tags.

--- a/R/typst.R
+++ b/R/typst.R
@@ -362,5 +362,10 @@ typst_cell_text <- function(ht, row, col, cell_text) {
     text <- sprintf("#block(breakable: false)[%s]", text)
   }
 
+  rot <- rotation(ht)[row, col]
+  if (!is.na(rot) && rot != 0) {
+    text <- sprintf("#rotate(%.4gdeg)[%s]", rot, text)
+  }
+
   text
 }

--- a/agent-notes.md
+++ b/agent-notes.md
@@ -17,3 +17,4 @@ your referring to.
 * Typst export outputs labels using `<label>` after the `#figure` block for cross-referencing. rev 088f1fe0
 * MarkdownTypstTranslator handles bold, italic, links, images, headings, strikethrough, inline code, and lists via `render_markdown("...", "typst")`. rev 45b775da
 * `to_typst()` now uses `clean_contents(..., output_type = "typst")` so markdown cells output Typst markup instead of TeX. rev d233e674
+* `typst_cell_text()` wraps rotated cells in `#rotate(angle)[...]` so Typst output now supports cell rotation. rev dda496d2

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -23,6 +23,7 @@ body rows in \verb{<tbody>} when header rows are at the top of the table.
 \item Added Typst export via \code{to_typst()} and \code{print_typst()}. Quarto
 integration is available as well as \code{quick_typst()} and
 \code{quick_typst_pdf()} functions.
+\item Typst output now supports cell rotation.
 \item HTML output now uses CSS classes with a shared \verb{<style>} block instead
 of long inline styles.
 \item Added \code{as_html()} for obtaining table as \code{htmltools} tags.

--- a/tests/testthat/test-typst.R
+++ b/tests/testthat/test-typst.R
@@ -218,3 +218,10 @@ test_that("height and row_height render in Typst", {
   expect_match(res, "block\\(height: 40%\\)")
   expect_match(res, "rows: (0.25fr, 0.75fr)", fixed = TRUE)
 })
+
+test_that("rotation renders in Typst", {
+  ht <- hux(a = 1:2, b = 3:4, add_colnames = FALSE)
+  rotation(ht)[1, 1] <- 90
+  res <- to_typst(ht)
+  expect_match(res, "#rotate(90deg)[1]", fixed = TRUE)
+})


### PR DESCRIPTION
## Summary
- support `rotation()` property in Typst backend via `#rotate(angle)`
- test Typst output for rotated cells
- document Typst rotation support in NEWS

## Testing
- `devtools::document()` *(fails: openxlsx, dplyr, flextable, lmtest packages missing)*
- `devtools::test(filter = "typst")`


------
https://chatgpt.com/codex/tasks/task_e_689a0e2f2b3c8330886d4d431c607bd6