### PR TITLE
chore: update lintr config for lintr v3

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,5 @@
-# use lintr::lint_package() to run this
-linters: with_defaults(
+linters: linters_with_defaults(
   line_length_linter(120),
-  single_quotes_linter = NULL,
-  indentation_linter(indent = 2L, no_tab = TRUE)
-)
+  indentation_linter(indent = 2L)
+  )
 exclusions: list("inst/doc/huxreg.R", "inst/doc/design-principles.R", "inst/doc/huxtable.R")


### PR DESCRIPTION
## Summary
- modernize `.lintr` for lintr v3 by using `linters_with_defaults`
- remove deprecated options and ensure config uses proper DCF continuation lines

## Testing
- `R -q -e 'lintr::lint("R/brdr.R")'`
- `R -q -e 'devtools::test(filter = "huxtable-creation", stop_on_failure = TRUE)'`


------
https://chatgpt.com/codex/tasks/task_e_689aefbf4bdc8330b8f23d024c94aabf