### PR TITLE
Remove tlmgr skip helpers added for LaTeX tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,7 +62,7 @@ Suggests:
     sandwich,
     scales,
     styler,
-    testthat,
+    testthat (>= 3.0.0),
     tibble,
     tinytex
 SystemRequirements: LaTeX packages: 
@@ -86,6 +86,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
-Depends: 
+Depends:
     R (>= 2.10)
 Config/testthat/edition: 3
+Config/testthat/parallel: true

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -3,4 +3,4 @@ library(huxtable)
 
 
 we_are_in_R_CMD_check <- TRUE
-test_check("huxtable")
+test_check("huxtable", parallel = TRUE)

--- a/tests/testthat/test-new-borders.R
+++ b/tests/testthat/test-new-borders.R
@@ -157,9 +157,6 @@ test_that("map_left_border", {
     ignore_attr = TRUE
   )
 
-  # ht8 <- map_left_border(ht, by_cases(. == 2 ~ brdr(1), TRUE ~ brdr(0)))
-  # expect_equivalent(left_border(ht8)[], matrix(c(0, 1, 1, 0), 2, 2))
-
   ht9 <- map_left_border(ht, by_quantiles(0.5, list(brdr(0), brdr(1))))
   expect_equal(
     brdr_thickness(left_border(ht9)),
@@ -184,6 +181,20 @@ test_that("map_left_border", {
 
   ht7 <- map_left_border(ht, by_function(function(x) brdr(1)))
   expect_equal(brdr_thickness(left_border(ht7)), matrix(1, 2, 2), ignore_attr = TRUE)
+})
+
+
+test_that("map_left_border supports dplyr by_cases helper", {
+  skip_if_not_installed("dplyr")
+
+  ht <- hux(1:2, 2:1)
+  ht2 <- map_left_border(ht, by_cases(. == 2 ~ brdr(1), TRUE ~ brdr(0)))
+
+  expect_equal(
+    brdr_thickness(left_border(ht2)),
+    matrix(c(0, 1, 1, 0), 2, 2),
+    ignore_attr = TRUE
+  )
 })
 
 


### PR DESCRIPTION
## Summary
- remove tlmgr/latex skip helpers from shared test setup and associated test files
- restore quick-output’s local latex dependency check instead of global skip helper
- drop LaTeX skip gates added to markdown and end-to-end tests to focus on edition 3 changes

## Testing
- R -q -e "devtools::test(filter='new-borders')"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0b4d016483308a3e2c667849f54a)