### PR TITLE
Move lintr out of Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,6 @@ Suggests:
     knitr,
     lme4,
     lmtest,
-    lintr,
     nlme,
     nnet,
     officer,
@@ -89,3 +88,4 @@ Roxygen: list(markdown = TRUE)
 Depends: 
     R (>= 2.10)
 Config/testthat/edition: 3
+Config/needs/development: lintr


### PR DESCRIPTION
Thanks for using {lintr}!

That said, I don't think the package actually _uses_ it (there's no `lintr::` usage in the package), so we can reduce the dependency web of {lintr} by moving it elsewhere in the DESCRIPTION to mark it as "this package uses {lintr} to keep up code quality". There's not really a standard way to do so, but something like `Config/needs/development` or `Config/wants/development` feel OK to me.