### PR TITLE
Avoid mutating knitr chunk options for autolabels

### DIFF
--- a/R/captions.R
+++ b/R/captions.R
@@ -72,13 +72,23 @@ resolve_caption <- function(ht, format = c("html", "latex", "md", "typst")) {
   lab <- label(ht)
 
   has_knitr <- requireNamespace("knitr", quietly = TRUE)
-  chunk_label <- if (has_knitr) knitr::opts_current$get("label") else NULL
+  chunk_options <- if (has_knitr) knitr::opts_current$get() else NULL
+  chunk_label <- chunk_options$label
   if (length(chunk_label) > 0 && grepl("^unnamed-chunk", chunk_label)) {
     chunk_label <- NULL
   }
 
+  same_chunk <- identical(chunk_label, huxtable_env$autolabel_chunk$label) &&
+    rlang::is_reference(chunk_options, huxtable_env$autolabel_chunk$options)
+  if (!same_chunk) {
+    huxtable_env$autolabel_cache <- list()
+    huxtable_env$autolabel_chunk <- list(
+      label = chunk_label,
+      options = chunk_options
+    )
+  }
   used_labels <- if (!is.null(chunk_label)) {
-    knitr::opts_current$get("huxtable.used_labels")
+    huxtable_env$autolabel_cache[[chunk_label]]
   } else {
     NULL
   }
@@ -118,9 +128,7 @@ resolve_caption <- function(ht, format = c("html", "latex", "md", "typst")) {
   }
 
   if (!is.null(chunk_label) && !is.na(lab) && nzchar(lab)) {
-    knitr::opts_current$set(
-      huxtable.used_labels = unique(c(used_labels, lab))
-    )
+    huxtable_env$autolabel_cache[[chunk_label]] <- unique(c(used_labels, lab))
   }
 
   cap <- caption(ht)

--- a/R/property-helpers.R
+++ b/R/property-helpers.R
@@ -41,6 +41,8 @@ huxtable_table_attrs <- c(
 )
 
 huxtable_env <- new.env()
+huxtable_env$autolabel_cache <- list()
+huxtable_env$autolabel_chunk <- list(label = NULL, options = NULL)
 huxtable_env$huxtable_default_attrs <- list(
   rowspan             = 1,
   colspan             = 1,

--- a/design.md
+++ b/design.md
@@ -78,6 +78,7 @@ RTF and Excel use the raw caption property and the shared horizontal and
 vertical position helpers.
 
 Automatic labels are based on the knitr chunk label. Labels already emitted in
-the current chunk are stored in `knitr::opts_current`, so additional huxtables
-receive deterministic suffixes without state leaking into later chunks or later
-knitting runs.
+the current chunk are stored in a package-internal cache keyed by the chunk
+label. The cache is scoped to knitr's current chunk-options object, so
+additional huxtables receive deterministic suffixes without mutating knitr
+state or leaking labels into later chunks and knitting runs.

--- a/tests/testthat/test-captions.R
+++ b/tests/testthat/test-captions.R
@@ -3,12 +3,17 @@ skip_if_not_installed("knitr")
 
 test_that("Bugfix: multiple tables in a chunk get unique labels", {
   old_current <- knitr::opts_current$get()
-  on.exit(knitr::opts_current$restore(old_current))
+  on.exit({
+    knitr::opts_current$lock(FALSE)
+    knitr::opts_current$restore(old_current)
+  })
   knitr::opts_current$set(label = "run")
-  knitr::opts_current$delete("huxtable.used_labels")
+  knitr::opts_current$lock()
 
-  first <- to_latex(hux(a = 1))
-  second <- to_latex(hux(a = 2))
+  expect_no_warning({
+    first <- to_latex(hux(a = 1))
+    second <- to_latex(hux(a = 2))
+  })
 
   expect_match(first, "\\label{tab:run}", fixed = TRUE)
   expect_match(second, "\\label{tab:run-2}", fixed = TRUE)
@@ -19,7 +24,6 @@ test_that("Explicit labels are respected by automatic labels", {
   old_current <- knitr::opts_current$get()
   on.exit(knitr::opts_current$restore(old_current))
   knitr::opts_current$set(label = "run")
-  knitr::opts_current$delete("huxtable.used_labels")
 
   expect_equal(resolve_caption(set_label(hux(a = 1), "tab:run"), "html")$label, "tab:run")
   expect_equal(resolve_caption(hux(a = 2), "html")$label, "tab:run-2")
@@ -30,14 +34,13 @@ test_that("Automatic label state resets with knitr chunk state", {
   old_current <- knitr::opts_current$get()
   on.exit(knitr::opts_current$restore(old_current))
   knitr::opts_current$set(label = "run")
-  knitr::opts_current$delete("huxtable.used_labels")
 
   expect_equal(resolve_caption(hux(a = 1), "html")$label, "tab:run")
   expect_equal(resolve_caption(hux(a = 2), "html")$label, "tab:run-2")
 
   knitr::opts_current$restore(old_current)
-  knitr::opts_current$set(label = "next-run")
-  expect_equal(resolve_caption(hux(a = 3), "html")$label, "tab:next-run")
+  knitr::opts_current$set(label = "run")
+  expect_equal(resolve_caption(hux(a = 3), "html")$label, "tab:run")
 })
 
 


### PR DESCRIPTION
## Summary

- store emitted automatic labels in a package-internal cache keyed by chunk label
- scope the cache to knitr's current chunk-options object so repeated knitting runs reset cleanly
- preserve unique suffixes and explicit-label reservation without writing to opts_current
- add a regression test with locked knitr options to verify there is no warning
- update the architecture note to describe the cache

## Tests

- caption tests: 32 expectations passed
- renderer-adjacent tests: passed with 1 existing skip
- full non-fuzz suite: passed with 6 existing skips and expected warnings
- git diff --check