### PR TITLE
Register HTML and LaTeX dependencies once

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,11 @@
   workbook. Thanks @lemonad for the report.
 * `huxtable_html_css()` is now exported, for including huxtable's default CSS
   once in an HTML document.
+* In knitr, R Markdown and Quarto documents, huxtable's HTML styles and LaTeX
+  command definitions are now registered as document dependencies and emitted
+  once. Outside those documents, `to_html()`, `print_html()`, `to_latex()` and
+  `print_latex()` include them by default; use `dependencies = FALSE` to omit
+  them.
   
 # huxtable 5.8.0
 

--- a/R/html.R
+++ b/R/html.R
@@ -2,7 +2,7 @@
 #'
 #' @rdname to_html
 #'
-print_html <- function(ht, ..., dependencies = TRUE) {
+print_html <- function(ht, dependencies = TRUE, ...) {
   cat(to_html(ht, ..., dependencies = dependencies))
 }
 
@@ -15,7 +15,8 @@ print_html <- function(ht, ..., dependencies = TRUE) {
 #'
 #' @param ht A huxtable.
 #' @param ... Arguments passed to methods. Not currently used.
-#' @param dependencies Logical. If `TRUE`, include huxtable's CSS styles.
+#' @param dependencies Logical. If `TRUE`, include the CSS styles or LaTeX
+#'   command definitions required by huxtables.
 #'
 #' @return `to_html` returns an HTML string. `as_html` wraps `to_html` and returns an
 #'   `htmltools::HTML` object. `print_html` prints the string and returns `NULL`.
@@ -34,8 +35,8 @@ print_html <- function(ht, ..., dependencies = TRUE) {
 #'
 #' @return `print_notebook` prints HTML output suitable for use in an
 #' RStudio interactive notebook.
-print_notebook <- function(ht, ...) {
-  html <- to_html(ht, ...)
+print_notebook <- function(ht, dependencies = TRUE, ...) {
+  html <- to_html(ht, dependencies = dependencies, ...)
   print(rmarkdown::html_notebook_output_html(html))
 }
 
@@ -88,7 +89,7 @@ to_html <- function(ht, dependencies = TRUE, ...) {
 
 #' @export
 #' @rdname to_html
-as_html <- function(ht, ..., dependencies = TRUE) {
+as_html <- function(ht, dependencies = TRUE, ...) {
   assert_that(is.flag(dependencies))
   result <- htmltools::HTML(to_html(ht, ..., dependencies = FALSE))
   if (dependencies) {

--- a/R/html.R
+++ b/R/html.R
@@ -2,16 +2,20 @@
 #'
 #' @rdname to_html
 #'
-print_html <- function(ht, ...) cat(huxtable_html_css(), to_html(ht, ...))
+print_html <- function(ht, ..., dependencies = TRUE) {
+  cat(to_html(ht, ..., dependencies = dependencies))
+}
 
 
 #' Create HTML representing a huxtable
 #'
-#' These functions print or return an HTML table. `print_html` also prepends a
-#' `<style>` block defining basic CSS classes.
+#' These functions print or return an HTML table. By default, `to_html()` and
+#' `print_html()` prepend a `<style>` block defining basic CSS classes, while
+#' `as_html()` attaches the same styles as an HTML dependency.
 #'
 #' @param ht A huxtable.
 #' @param ... Arguments passed to methods. Not currently used.
+#' @param dependencies Logical. If `TRUE`, include huxtable's CSS styles.
 #'
 #' @return `to_html` returns an HTML string. `as_html` wraps `to_html` and returns an
 #'   `htmltools::HTML` object. `print_html` prints the string and returns `NULL`.
@@ -31,7 +35,7 @@ print_html <- function(ht, ...) cat(huxtable_html_css(), to_html(ht, ...))
 #' @return `print_notebook` prints HTML output suitable for use in an
 #' RStudio interactive notebook.
 print_notebook <- function(ht, ...) {
-  html <- paste0(huxtable_html_css(), to_html(ht))
+  html <- to_html(ht, ...)
   print(rmarkdown::html_notebook_output_html(html))
 }
 
@@ -47,36 +51,30 @@ print_notebook <- function(ht, ...) {
 #' @examples
 #' cat(huxtable_html_css())
 huxtable_html_css <- function() {
-  '<style>
-.huxtable {
-  border-collapse: collapse;
-  border: 0px;
-  margin-bottom: 2em;
-  margin-top: 2em;
+  css_path <- system.file("huxtable", "huxtable.css", package = "huxtable", mustWork = TRUE)
+  css <- paste(readLines(css_path, warn = FALSE), collapse = "\n")
+  paste0("<style>\n", css, "\n</style>\n")
 }
-.huxtable-cell {
-  vertical-align: top;
-  text-align: left;
-  white-space: normal;
-  border-style: solid;
-  border-width: 0pt;
-  padding: 6pt;
-  font-weight: normal;
-}
-.huxtable-header {
-  font-weight: bold;
-}
-.huxtable tr {
-  break-inside: avoid;
-  page-break-inside: avoid;
-}
-</style>
-'
+
+
+#' HTML dependency for huxtable styles
+#'
+#' @return An `htmltools::htmlDependency` object.
+#' @noRd
+huxtable_html_dependency <- function() {
+  htmltools::htmlDependency(
+    name = "huxtable",
+    version = as.character(utils::packageVersion("huxtable")),
+    src = "huxtable",
+    stylesheet = "huxtable.css",
+    package = "huxtable"
+  )
 }
 
 #' @export
 #' @rdname to_html
-to_html <- function(ht, ...) {
+to_html <- function(ht, dependencies = TRUE, ...) {
+  assert_that(is.flag(dependencies))
   check_positive_dims(ht)
 
   table_start <- build_table_style(ht)
@@ -84,13 +82,19 @@ to_html <- function(ht, ...) {
   cell_html <- build_cell_html(ht)
   row_html <- build_row_html(ht, cell_html)
 
-  paste0(table_start, cols_html, row_html, "</table>\n")
+  table_html <- paste0(table_start, cols_html, row_html, "</table>\n")
+  if (dependencies) paste0(huxtable_html_css(), table_html) else table_html
 }
 
 #' @export
 #' @rdname to_html
-as_html <- function(ht, ...) {
-  htmltools::HTML(to_html(ht, ...))
+as_html <- function(ht, ..., dependencies = TRUE) {
+  assert_that(is.flag(dependencies))
+  result <- htmltools::HTML(to_html(ht, ..., dependencies = FALSE))
+  if (dependencies) {
+    result <- htmltools::attachDependencies(result, huxtable_html_dependency())
+  }
+  result
 }
 
 #' Build opening table tag and caption for HTML output

--- a/R/knitr.R
+++ b/R/knitr.R
@@ -38,7 +38,9 @@ knit_print.huxtable <- function(x, options, ...) {
     }
   )
 
-  res <- do.call(call_name, list(x))
+  call_args <- list(x)
+  if (of %in% c("html", "latex")) call_args$dependencies <- FALSE
+  res <- do.call(call_name, call_args)
 
   res <- switch(of,
     latex = {
@@ -50,7 +52,8 @@ knit_print.huxtable <- function(x, options, ...) {
       knitr::asis_output(res, meta = latex_deps)
     },
     html = knitr::asis_output(
-      htmltools::htmlPreserve(res)
+      htmltools::htmlPreserve(res),
+      meta = list(huxtable_html_dependency())
     ),
     rtf = knitr::raw_output(res),
     pptx = ,

--- a/R/knitr.R
+++ b/R/knitr.R
@@ -45,6 +45,8 @@ knit_print.huxtable <- function(x, options, ...) {
   res <- switch(of,
     latex = {
       latex_deps <- report_latex_dependencies(quiet = TRUE)
+      array_dep <- match("array", vapply(latex_deps, `[[`, "", "name"))
+      latex_deps[[array_dep]]$extra_lines <- huxtable_latex_commands()
       tenv <- tabular_environment(x)
       if (tenv %in% "tabulary") {
         latex_deps <- c(latex_deps, list(rmarkdown::latex_dependency(tenv)))

--- a/R/latex-dependencies.R
+++ b/R/latex-dependencies.R
@@ -2,8 +2,22 @@
 NULL
 
 
+#' LaTeX commands used by huxtables
+#'
+#' @return A character vector of LaTeX command definitions.
+#' @noRd
+huxtable_latex_commands <- function() {
+  c(
+    "\\providecommand{\\huxb}[2]{\\arrayrulecolor[RGB]{#1}\\global\\arrayrulewidth=#2pt}",
+    "\\providecommand{\\huxvb}[2]{\\color[RGB]{#1}\\vrule width #2pt}",
+    "\\providecommand{\\huxtpad}[1]{\\rule{0pt}{#1}}",
+    "\\providecommand{\\huxbpad}[1]{\\rule[-#1]{0pt}{#1}}"
+  )
+}
+
+
 huxtable_latex_dependencies <- list(
-  list(name = "array"),
+  list(name = "array", extra_lines = huxtable_latex_commands()),
   list(name = "caption"),
   list(name = "graphicx"),
   list(name = "siunitx"),
@@ -31,8 +45,8 @@ huxtable_latex_dependencies <- list(
 #' @param as_string Logical: return dependencies as a string.
 #'
 #' @return If `as_string` is `TRUE`, `report_latex_dependencies` returns a string of
-#'   `"\\\\usepackage\\{...\\}"` statements; otherwise it returns a list of
-#'   `rmarkdown::latex_dependency` objects, invisibly.
+#'   `"\\\\usepackage\\{...\\}"` statements and huxtable's LaTeX command definitions;
+#'   otherwise it returns a list of `rmarkdown::latex_dependency` objects, invisibly.
 #' @export
 #'
 #' @examples
@@ -54,6 +68,9 @@ report_latex_dependencies <- function(quiet = FALSE, as_string = FALSE) {
       package_str <- paste0(package_str, "[", options_str, "]")
     }
     package_str <- paste0(package_str, "{", ld$name, "}\n")
+    if (!is.null(ld$extra_lines)) {
+      package_str <- paste0(package_str, paste(ld$extra_lines, collapse = "\n"), "\n")
+    }
     package_str
   })
   if (!quiet) {

--- a/R/latex-dependencies.R
+++ b/R/latex-dependencies.R
@@ -17,7 +17,7 @@ huxtable_latex_commands <- function() {
 
 
 huxtable_latex_dependencies <- list(
-  list(name = "array", extra_lines = huxtable_latex_commands()),
+  list(name = "array"),
   list(name = "caption"),
   list(name = "graphicx"),
   list(name = "siunitx"),
@@ -45,8 +45,8 @@ huxtable_latex_dependencies <- list(
 #' @param as_string Logical: return dependencies as a string.
 #'
 #' @return If `as_string` is `TRUE`, `report_latex_dependencies` returns a string of
-#'   `"\\\\usepackage\\{...\\}"` statements and huxtable's LaTeX command definitions;
-#'   otherwise it returns a list of `rmarkdown::latex_dependency` objects, invisibly.
+#'   `"\\\\usepackage\\{...\\}"` statements; otherwise it returns a list of
+#'   `rmarkdown::latex_dependency` objects, invisibly.
 #' @export
 #'
 #' @examples
@@ -68,9 +68,6 @@ report_latex_dependencies <- function(quiet = FALSE, as_string = FALSE) {
       package_str <- paste0(package_str, "[", options_str, "]")
     }
     package_str <- paste0(package_str, "{", ld$name, "}\n")
-    if (!is.null(ld$extra_lines)) {
-      package_str <- paste0(package_str, paste(ld$extra_lines, collapse = "\n"), "\n")
-    }
     package_str
   })
   if (!quiet) {

--- a/R/latex.R
+++ b/R/latex.R
@@ -9,18 +9,15 @@ default_table_width_unit <- "\\textwidth"
 
 #' @export
 #' @rdname to_latex
-print_latex <- function(ht, ..., dependencies = TRUE) {
+print_latex <- function(ht, dependencies = TRUE, ...) {
   cat(to_latex(ht, ..., dependencies = dependencies))
 }
 
 
 #' Create LaTeX representing a huxtable
 #'
-#' @param ht A huxtable.
+#' @inheritParams to_html
 #' @param tabular_only Return only the LaTeX tabular, not the surrounding float.
-#' @param dependencies Logical. If `TRUE`, include the LaTeX command definitions
-#'   used by huxtables.
-#' @param ... Arguments passed to methods.
 #'
 #' @details
 #' If we appear to be in a rmarkdown document with the Pandoc markdown `+raw_attribute` extension

--- a/R/latex.R
+++ b/R/latex.R
@@ -9,8 +9,8 @@ default_table_width_unit <- "\\textwidth"
 
 #' @export
 #' @rdname to_latex
-print_latex <- function(ht, ...) {
-  cat(to_latex(ht, ...))
+print_latex <- function(ht, ..., dependencies = TRUE) {
+  cat(to_latex(ht, ..., dependencies = dependencies))
 }
 
 
@@ -18,6 +18,8 @@ print_latex <- function(ht, ...) {
 #'
 #' @param ht A huxtable.
 #' @param tabular_only Return only the LaTeX tabular, not the surrounding float.
+#' @param dependencies Logical. If `TRUE`, include the LaTeX command definitions
+#'   used by huxtables.
 #' @param ... Arguments passed to methods.
 #'
 #' @details
@@ -37,8 +39,8 @@ print_latex <- function(ht, ...) {
 #'   b = letters[1:3]
 #' )
 #' print_latex(ht)
-to_latex <- function(ht, tabular_only = FALSE, ...) {
-  assert_that(is.flag(tabular_only))
+to_latex <- function(ht, tabular_only = FALSE, dependencies = TRUE, ...) {
+  assert_that(is.flag(tabular_only), is.flag(dependencies))
   if (breakable(ht)) {
     if (!is.na(height(ht))) {
       stop("Breakable LaTeX tables cannot have a fixed height.", call. = FALSE)
@@ -57,11 +59,11 @@ to_latex <- function(ht, tabular_only = FALSE, ...) {
       "\\colorbox[RGB]{", bg, "}{", tabular, "}}"
     )
   }
-  commands <- "
-  \\providecommand{\\huxb}[2]{\\arrayrulecolor[RGB]{#1}\\global\\arrayrulewidth=#2pt}
-  \\providecommand{\\huxvb}[2]{\\color[RGB]{#1}\\vrule width #2pt}
-  \\providecommand{\\huxtpad}[1]{\\rule{0pt}{#1}}
-  \\providecommand{\\huxbpad}[1]{\\rule[-#1]{0pt}{#1}}\n"
+  commands <- if (dependencies) {
+    paste0("\n  ", paste(huxtable_latex_commands(), collapse = "\n  "), "\n")
+  } else {
+    ""
+  }
 
   if (tabular_only) {
     return(maybe_markdown_fence(paste0(commands, tabular)))

--- a/R/quick-functions.R
+++ b/R/quick-functions.R
@@ -250,9 +250,10 @@ quick_html <- function(
   )
   tryCatch(
     {
+      cat(huxtable_html_css())
       lapply(hts, function(ht) {
         cat("<p>&nbsp;</p>")
-        print_html(ht)
+        print_html(ht, dependencies = FALSE)
         cat("\n\n")
       })
       cat("</body></html>")
@@ -401,7 +402,7 @@ do_write_latex_file <- function(hts, file, width, height) {
       cat("\n\\begin{document}")
       lapply(hts, function(ht) {
         cat("\n\n")
-        print_latex(ht)
+        print_latex(ht, dependencies = FALSE)
         cat("\n\n")
       })
       cat("\n\\end{document}")

--- a/R/quick-functions.R
+++ b/R/quick-functions.R
@@ -242,15 +242,15 @@ quick_html <- function(
   cat("<!DOCTYPE html>",
     sprintf("<html lang=\"%s\">", loc[1]),
     sprintf(
-      "<head><meta charset=\"%s\"><title>%s</title></head>",
+      "<head><meta charset=\"%s\"><title>%s</title>",
       loc[2], basename(file)
     ),
-    "<body>\n",
     sep = "\n"
   )
+  cat(huxtable_html_css())
+  cat("</head>", "<body>\n", sep = "\n")
   tryCatch(
     {
-      cat(huxtable_html_css())
       lapply(hts, function(ht) {
         cat("<p>&nbsp;</p>")
         print_html(ht, dependencies = FALSE)
@@ -391,6 +391,7 @@ do_write_latex_file <- function(hts, file, width, height) {
     {
       cat("\\documentclass{article}\n")
       report_latex_dependencies()
+      cat(paste(huxtable_latex_commands(), collapse = "\n"), "\n", sep = "")
       if (!is.null(width) || !is.null(height)) {
         dim_string <- character(2)
         dim_string[1] <- if (is.null(width)) "" else sprintf("paperwidth=%s", width)

--- a/design.md
+++ b/design.md
@@ -68,12 +68,15 @@ so the workbook contains one style record per distinct style and table rather
 than one record per cell【F:R/Workbook.R†L64-L218】.
 
 ## Integration with R Markdown
-When a huxtable is printed in a knitr/Rmarkdown context, 
+When a huxtable is printed in a knitr/Rmarkdown context,
 `knit_print.huxtable()` is invoked.  It detects the desired output format 
 (`latex`, `html`, `rtf`, etc.) via `guess_knitr_output_format()` and dispatches 
-to the corresponding renderer (`to_latex`, `to_html`, `to_md`, etc.).  For 
-LaTeX and HTML, the returned markup is passed to knitr as-is, possibly with 
-additional dependencies for LaTeX packages【F:R/knitr.R†L18-L60】.
+to the corresponding renderer (`to_latex`, `to_html`, `to_md`, etc.). For
+LaTeX and HTML, it asks the renderer to omit inline dependencies and registers
+the CSS or LaTeX packages and command definitions as knitr metadata. Document
+engines can then emit these dependencies once even when there are several
+tables. Direct calls to the HTML and LaTeX renderers include their CSS or
+command definitions by default so their output remains standalone.
 
 Caption and label behavior shared by the renderers is implemented in
 `R/captions.R`. `resolve_caption()` returns caption text, the resolved label,

--- a/inst/huxtable/huxtable.css
+++ b/inst/huxtable/huxtable.css
@@ -1,0 +1,22 @@
+.huxtable {
+  border-collapse: collapse;
+  border: 0px;
+  margin-bottom: 2em;
+  margin-top: 2em;
+}
+.huxtable-cell {
+  vertical-align: top;
+  text-align: left;
+  white-space: normal;
+  border-style: solid;
+  border-width: 0pt;
+  padding: 6pt;
+  font-weight: normal;
+}
+.huxtable-header {
+  font-weight: bold;
+}
+.huxtable tr {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -26,6 +26,11 @@ a data frame.
 workbook. Thanks @lemonad for the report.
 \item \code{huxtable_html_css()} is now exported, for including huxtable’s
 default CSS once in an HTML document.
+\item In knitr, R Markdown and Quarto documents, huxtable’s HTML styles and
+LaTeX command definitions are now registered as document dependencies
+and emitted once. Outside those documents, \code{to_html()},
+\code{print_html()}, \code{to_latex()} and \code{print_latex()} include them by
+default; use \code{dependencies = FALSE} to omit them.
 }
 }
 

--- a/man/report_latex_dependencies.Rd
+++ b/man/report_latex_dependencies.Rd
@@ -20,8 +20,8 @@ For \code{check_latex_dependencies}, suppress messages.}
 }
 \value{
 If \code{as_string} is \code{TRUE}, \code{report_latex_dependencies} returns a string of
-\code{"\\\\\\\\usepackage\\\\{...\\\\}"} statements; otherwise it returns a list of
-\code{rmarkdown::latex_dependency} objects, invisibly.
+\code{"\\\\\\\\usepackage\\\\{...\\\\}"} statements and huxtable's LaTeX command definitions;
+otherwise it returns a list of \code{rmarkdown::latex_dependency} objects, invisibly.
 
 \code{check_latex_dependencies()} returns \code{TRUE} or \code{FALSE}.
 

--- a/man/report_latex_dependencies.Rd
+++ b/man/report_latex_dependencies.Rd
@@ -20,8 +20,8 @@ For \code{check_latex_dependencies}, suppress messages.}
 }
 \value{
 If \code{as_string} is \code{TRUE}, \code{report_latex_dependencies} returns a string of
-\code{"\\\\\\\\usepackage\\\\{...\\\\}"} statements and huxtable's LaTeX command definitions;
-otherwise it returns a list of \code{rmarkdown::latex_dependency} objects, invisibly.
+\code{"\\\\\\\\usepackage\\\\{...\\\\}"} statements; otherwise it returns a list of
+\code{rmarkdown::latex_dependency} objects, invisibly.
 
 \code{check_latex_dependencies()} returns \code{TRUE} or \code{FALSE}.
 

--- a/man/to_html.Rd
+++ b/man/to_html.Rd
@@ -7,18 +7,20 @@
 \alias{as_html}
 \title{Create HTML representing a huxtable}
 \usage{
-print_html(ht, ...)
+print_html(ht, ..., dependencies = TRUE)
 
 print_notebook(ht, ...)
 
-to_html(ht, ...)
+to_html(ht, dependencies = TRUE, ...)
 
-as_html(ht, ...)
+as_html(ht, ..., dependencies = TRUE)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
 \item{...}{Arguments passed to methods. Not currently used.}
+
+\item{dependencies}{Logical. If \code{TRUE}, include huxtable's CSS styles.}
 }
 \value{
 \code{to_html} returns an HTML string. \code{as_html} wraps \code{to_html} and returns an
@@ -28,8 +30,9 @@ as_html(ht, ...)
 RStudio interactive notebook.
 }
 \description{
-These functions print or return an HTML table. \code{print_html} also prepends a
-\verb{<style>} block defining basic CSS classes.
+These functions print or return an HTML table. By default, \code{to_html()} and
+\code{print_html()} prepend a \verb{<style>} block defining basic CSS classes, while
+\code{as_html()} attaches the same styles as an HTML dependency.
 }
 \examples{
 ht <- hux(a = 1:3, b = letters[1:3])

--- a/man/to_html.Rd
+++ b/man/to_html.Rd
@@ -7,20 +7,21 @@
 \alias{as_html}
 \title{Create HTML representing a huxtable}
 \usage{
-print_html(ht, ..., dependencies = TRUE)
+print_html(ht, dependencies = TRUE, ...)
 
-print_notebook(ht, ...)
+print_notebook(ht, dependencies = TRUE, ...)
 
 to_html(ht, dependencies = TRUE, ...)
 
-as_html(ht, ..., dependencies = TRUE)
+as_html(ht, dependencies = TRUE, ...)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{...}{Arguments passed to methods. Not currently used.}
+\item{dependencies}{Logical. If \code{TRUE}, include the CSS styles or LaTeX
+command definitions required by huxtables.}
 
-\item{dependencies}{Logical. If \code{TRUE}, include huxtable's CSS styles.}
+\item{...}{Arguments passed to methods. Not currently used.}
 }
 \value{
 \code{to_html} returns an HTML string. \code{as_html} wraps \code{to_html} and returns an

--- a/man/to_latex.Rd
+++ b/man/to_latex.Rd
@@ -5,14 +5,17 @@
 \alias{to_latex}
 \title{Create LaTeX representing a huxtable}
 \usage{
-print_latex(ht, ...)
+print_latex(ht, ..., dependencies = TRUE)
 
-to_latex(ht, tabular_only = FALSE, ...)
+to_latex(ht, tabular_only = FALSE, dependencies = TRUE, ...)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
 \item{...}{Arguments passed to methods.}
+
+\item{dependencies}{Logical. If \code{TRUE}, include the LaTeX command definitions
+used by huxtables.}
 
 \item{tabular_only}{Return only the LaTeX tabular, not the surrounding float.}
 }

--- a/man/to_latex.Rd
+++ b/man/to_latex.Rd
@@ -5,17 +5,17 @@
 \alias{to_latex}
 \title{Create LaTeX representing a huxtable}
 \usage{
-print_latex(ht, ..., dependencies = TRUE)
+print_latex(ht, dependencies = TRUE, ...)
 
 to_latex(ht, tabular_only = FALSE, dependencies = TRUE, ...)
 }
 \arguments{
 \item{ht}{A huxtable.}
 
-\item{...}{Arguments passed to methods.}
+\item{dependencies}{Logical. If \code{TRUE}, include the CSS styles or LaTeX
+command definitions required by huxtables.}
 
-\item{dependencies}{Logical. If \code{TRUE}, include the LaTeX command definitions
-used by huxtables.}
+\item{...}{Arguments passed to methods. Not currently used.}
 
 \item{tabular_only}{Return only the LaTeX tabular, not the surrounding float.}
 }

--- a/tests/testthat/_snaps/text/validate-outputs/borders.html
+++ b/tests/testthat/_snaps/text/validate-outputs/borders.html
@@ -3,7 +3,7 @@
 <head><meta charset="UTF-8"><title>borders.html</title></head>
 <body>
 
-<p>&nbsp;</p><style>
+<style>
 .huxtable {
   border-collapse: collapse;
   border: 0px;
@@ -27,7 +27,7 @@
   page-break-inside: avoid;
 }
 </style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Border properties: top_border thickness=3, color=red, style=dashed/double</caption><col><col><col><thead>
 <tr>
 <th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 3pt 1pt;      font-weight: normal;">Description</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 3pt 1pt;      font-weight: normal;">Top border</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 3pt 1pt;      font-weight: normal;">Bottom border</th></tr>

--- a/tests/testthat/_snaps/text/validate-outputs/borders.html
+++ b/tests/testthat/_snaps/text/validate-outputs/borders.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>borders.html</title></head>
-<body>
-
+<head><meta charset="UTF-8"><title>borders.html</title>
 <style>
 .huxtable {
   border-collapse: collapse;
@@ -27,6 +25,9 @@
   page-break-inside: avoid;
 }
 </style>
+</head>
+<body>
+
 <p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Border properties: top_border thickness=3, color=red, style=dashed/double</caption><col><col><col><thead>
 <tr>

--- a/tests/testthat/_snaps/text/validate-outputs/borders.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/borders.tex
@@ -1,5 +1,9 @@
 \documentclass{article}
 \usepackage{array}
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -22,11 +26,6 @@
 
 \begin{document}
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \begin{centerbox}

--- a/tests/testthat/_snaps/text/validate-outputs/borders.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/borders.tex
@@ -1,9 +1,5 @@
 \documentclass{article}
 \usepackage{array}
-\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -21,6 +17,10 @@
 % These are LaTeX packages. You can install them using your LaTex management software,
 % or by running `huxtable::install_latex_dependencies()` from within R.
 % Other packages may be required if you use non-standard tabulars (e.g. tabulary).
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \pagenumbering{gobble}
 

--- a/tests/testthat/_snaps/text/validate-outputs/cell_spanning.html
+++ b/tests/testthat/_snaps/text/validate-outputs/cell_spanning.html
@@ -3,7 +3,7 @@
 <head><meta charset="UTF-8"><title>cell_spanning.html</title></head>
 <body>
 
-<p>&nbsp;</p><style>
+<style>
 .huxtable {
   border-collapse: collapse;
   border: 0px;
@@ -27,7 +27,7 @@
   page-break-inside: avoid;
 }
 </style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Cell spanning: colspan=2, rowspan=2, combined colspan+rowspan</caption><col><col><col><col><tbody>
 <tr>
 <td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">normal cell</td><td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">normal cell</td><td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">normal</td><td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">normal</td></tr>

--- a/tests/testthat/_snaps/text/validate-outputs/cell_spanning.html
+++ b/tests/testthat/_snaps/text/validate-outputs/cell_spanning.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>cell_spanning.html</title></head>
-<body>
-
+<head><meta charset="UTF-8"><title>cell_spanning.html</title>
 <style>
 .huxtable {
   border-collapse: collapse;
@@ -27,6 +25,9 @@
   page-break-inside: avoid;
 }
 </style>
+</head>
+<body>
+
 <p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Cell spanning: colspan=2, rowspan=2, combined colspan+rowspan</caption><col><col><col><col><tbody>
 <tr>

--- a/tests/testthat/_snaps/text/validate-outputs/cell_spanning.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/cell_spanning.tex
@@ -1,5 +1,9 @@
 \documentclass{article}
 \usepackage{array}
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -22,11 +26,6 @@
 
 \begin{document}
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \begin{centerbox}

--- a/tests/testthat/_snaps/text/validate-outputs/cell_spanning.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/cell_spanning.tex
@@ -1,9 +1,5 @@
 \documentclass{article}
 \usepackage{array}
-\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -21,6 +17,10 @@
 % These are LaTeX packages. You can install them using your LaTex management software,
 % or by running `huxtable::install_latex_dependencies()` from within R.
 % Other packages may be required if you use non-standard tabulars (e.g. tabulary).
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \pagenumbering{gobble}
 

--- a/tests/testthat/_snaps/text/validate-outputs/content_formatting.html
+++ b/tests/testthat/_snaps/text/validate-outputs/content_formatting.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>content_formatting.html</title></head>
-<body>
-
+<head><meta charset="UTF-8"><title>content_formatting.html</title>
 <style>
 .huxtable {
   border-collapse: collapse;
@@ -27,6 +25,9 @@
   page-break-inside: avoid;
 }
 </style>
+</head>
+<body>
+
 <p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Content formatting: number_format, na_string, escape_contents, decimal align</caption><col><col><col><col><thead>
 <tr>

--- a/tests/testthat/_snaps/text/validate-outputs/content_formatting.html
+++ b/tests/testthat/_snaps/text/validate-outputs/content_formatting.html
@@ -3,7 +3,7 @@
 <head><meta charset="UTF-8"><title>content_formatting.html</title></head>
 <body>
 
-<p>&nbsp;</p><style>
+<style>
 .huxtable {
   border-collapse: collapse;
   border: 0px;
@@ -27,7 +27,7 @@
   page-break-inside: avoid;
 }
 </style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Content formatting: number_format, na_string, escape_contents, decimal align</caption><col><col><col><col><thead>
 <tr>
 <th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Property</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Raw value</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Formatted</th><th class="huxtable-cell huxtable-header" style="text-align: right;  border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Decimal align&nbsp;&nbsp;&nbsp;</th></tr>

--- a/tests/testthat/_snaps/text/validate-outputs/content_formatting.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/content_formatting.tex
@@ -1,5 +1,9 @@
 \documentclass{article}
 \usepackage{array}
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -22,11 +26,6 @@
 
 \begin{document}
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \begin{centerbox}

--- a/tests/testthat/_snaps/text/validate-outputs/content_formatting.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/content_formatting.tex
@@ -1,9 +1,5 @@
 \documentclass{article}
 \usepackage{array}
-\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -21,6 +17,10 @@
 % These are LaTeX packages. You can install them using your LaTex management software,
 % or by running `huxtable::install_latex_dependencies()` from within R.
 % Other packages may be required if you use non-standard tabulars (e.g. tabulary).
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \pagenumbering{gobble}
 

--- a/tests/testthat/_snaps/text/validate-outputs/dimensions.html
+++ b/tests/testthat/_snaps/text/validate-outputs/dimensions.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>dimensions.html</title></head>
-<body>
-
+<head><meta charset="UTF-8"><title>dimensions.html</title>
 <style>
 .huxtable {
   border-collapse: collapse;
@@ -27,6 +25,9 @@
   page-break-inside: avoid;
 }
 </style>
+</head>
+<body>
+
 <p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Dimensions: col_width=(0.2, 0.3, 0.35, 0.15)=1.0, row_height=(0.15, 0.15, 0.15, 0.15, 0.4)</caption><col style="width: 20%"><col style="width: 30%"><col style="width: 35%"><col style="width: 15%"><thead>
 <tr style="height: 15%;">

--- a/tests/testthat/_snaps/text/validate-outputs/dimensions.html
+++ b/tests/testthat/_snaps/text/validate-outputs/dimensions.html
@@ -3,7 +3,7 @@
 <head><meta charset="UTF-8"><title>dimensions.html</title></head>
 <body>
 
-<p>&nbsp;</p><style>
+<style>
 .huxtable {
   border-collapse: collapse;
   border: 0px;
@@ -27,7 +27,7 @@
   page-break-inside: avoid;
 }
 </style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Dimensions: col_width=(0.2, 0.3, 0.35, 0.15)=1.0, row_height=(0.15, 0.15, 0.15, 0.15, 0.4)</caption><col style="width: 20%"><col style="width: 30%"><col style="width: 35%"><col style="width: 15%"><thead>
 <tr style="height: 15%;">
 <th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">col_width=0.2</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">col_width=0.3</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">col_width=0.35</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Row Heights</th></tr>

--- a/tests/testthat/_snaps/text/validate-outputs/dimensions.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/dimensions.tex
@@ -1,5 +1,9 @@
 \documentclass{article}
 \usepackage{array}
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -22,11 +26,6 @@
 
 \begin{document}
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \begin{centerbox}

--- a/tests/testthat/_snaps/text/validate-outputs/dimensions.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/dimensions.tex
@@ -1,9 +1,5 @@
 \documentclass{article}
 \usepackage{array}
-\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -21,6 +17,10 @@
 % These are LaTeX packages. You can install them using your LaTex management software,
 % or by running `huxtable::install_latex_dependencies()` from within R.
 % Other packages may be required if you use non-standard tabulars (e.g. tabulary).
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \pagenumbering{gobble}
 

--- a/tests/testthat/_snaps/text/validate-outputs/table_caption_tests.html
+++ b/tests/testthat/_snaps/text/validate-outputs/table_caption_tests.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>table_caption_tests.html</title></head>
-<body>
-
+<head><meta charset="UTF-8"><title>table_caption_tests.html</title>
 <style>
 .huxtable {
   border-collapse: collapse;
@@ -27,6 +25,9 @@
   page-break-inside: avoid;
 }
 </style>
+</head>
+<body>
+
 <p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Table 1: caption_pos="top" (default)</caption><col><tbody>
 <tr>

--- a/tests/testthat/_snaps/text/validate-outputs/table_caption_tests.html
+++ b/tests/testthat/_snaps/text/validate-outputs/table_caption_tests.html
@@ -3,7 +3,7 @@
 <head><meta charset="UTF-8"><title>table_caption_tests.html</title></head>
 <body>
 
-<p>&nbsp;</p><style>
+<style>
 .huxtable {
   border-collapse: collapse;
   border: 0px;
@@ -27,7 +27,7 @@
   page-break-inside: avoid;
 }
 </style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Table 1: caption_pos="top" (default)</caption><col><tbody>
 <tr>
 <td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">caption_pos=top</td></tr>
@@ -35,31 +35,7 @@
 </table>
 
 
-<p>&nbsp;</p><style>
-.huxtable {
-  border-collapse: collapse;
-  border: 0px;
-  margin-bottom: 2em;
-  margin-top: 2em;
-}
-.huxtable-cell {
-  vertical-align: top;
-  text-align: left;
-  white-space: normal;
-  border-style: solid;
-  border-width: 0pt;
-  padding: 6pt;
-  font-weight: normal;
-}
-.huxtable-header {
-  font-weight: bold;
-}
-.huxtable tr {
-  break-inside: avoid;
-  page-break-inside: avoid;
-}
-</style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: bottom; text-align: center;">Table 2: caption_pos="bottom"</caption><col><tbody>
 <tr>
 <td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">caption_pos=bottom</td></tr>
@@ -67,31 +43,7 @@
 </table>
 
 
-<p>&nbsp;</p><style>
-.huxtable {
-  border-collapse: collapse;
-  border: 0px;
-  margin-bottom: 2em;
-  margin-top: 2em;
-}
-.huxtable-cell {
-  vertical-align: top;
-  text-align: left;
-  white-space: normal;
-  border-style: solid;
-  border-width: 0pt;
-  padding: 6pt;
-  font-weight: normal;
-}
-.huxtable-header {
-  font-weight: bold;
-}
-.huxtable tr {
-  break-inside: avoid;
-  page-break-inside: avoid;
-}
-</style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;width: 50%;">Table 3: caption_width=0.5 - This is a longer caption to demonstrate width constraint</caption><col><tbody>
 <tr>
 <td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">caption_width=0.5</td></tr>
@@ -99,31 +51,7 @@
 </table>
 
 
-<p>&nbsp;</p><style>
-.huxtable {
-  border-collapse: collapse;
-  border: 0px;
-  margin-bottom: 2em;
-  margin-top: 2em;
-}
-.huxtable-cell {
-  vertical-align: top;
-  text-align: left;
-  white-space: normal;
-  border-style: solid;
-  border-width: 0pt;
-  padding: 6pt;
-  font-weight: normal;
-}
-.huxtable-header {
-  font-weight: bold;
-}
-.huxtable tr {
-  break-inside: avoid;
-  page-break-inside: avoid;
-}
-</style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;width: 80%;">Table 4: caption_width=0.8 - This is a longer caption to demonstrate width constraint</caption><col><tbody>
 <tr>
 <td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">caption_width=0.8</td></tr>

--- a/tests/testthat/_snaps/text/validate-outputs/table_caption_tests.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/table_caption_tests.tex
@@ -1,5 +1,9 @@
 \documentclass{article}
 \usepackage{array}
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -22,11 +26,6 @@
 
 \begin{document}
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \begin{centerbox}
@@ -54,11 +53,6 @@
 
 
 
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
-
 \begin{table}[ht]
 \begin{centerbox}
 \begin{threeparttable}
@@ -85,11 +79,6 @@
 
 
 
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
-
 \begin{table}[ht]
 \captionsetup{justification=centering,margin={(\textwidth -  0.5\textwidth)/2,(\textwidth -  0.5\textwidth)/2},singlelinecheck=off}
 \caption{Table 3: caption_width=0.5 - This is a longer caption to demonstrate width constraint}
@@ -113,11 +102,6 @@
 
 
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \captionsetup{justification=centering,margin={(\textwidth -  0.8\textwidth)/2,(\textwidth -  0.8\textwidth)/2},singlelinecheck=off}

--- a/tests/testthat/_snaps/text/validate-outputs/table_caption_tests.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/table_caption_tests.tex
@@ -1,9 +1,5 @@
 \documentclass{article}
 \usepackage{array}
-\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -21,6 +17,10 @@
 % These are LaTeX packages. You can install them using your LaTex management software,
 % or by running `huxtable::install_latex_dependencies()` from within R.
 % Other packages may be required if you use non-standard tabulars (e.g. tabulary).
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \pagenumbering{gobble}
 

--- a/tests/testthat/_snaps/text/validate-outputs/table_pos_tests.html
+++ b/tests/testthat/_snaps/text/validate-outputs/table_pos_tests.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>table_pos_tests.html</title></head>
-<body>
-
+<head><meta charset="UTF-8"><title>table_pos_tests.html</title>
 <style>
 .huxtable {
   border-collapse: collapse;
@@ -27,6 +25,9 @@
   page-break-inside: avoid;
 }
 </style>
+</head>
+<body>
+
 <p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: 0%; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: left;">Table 1: position="left"</caption><col><tbody>
 <tr>

--- a/tests/testthat/_snaps/text/validate-outputs/table_pos_tests.html
+++ b/tests/testthat/_snaps/text/validate-outputs/table_pos_tests.html
@@ -3,7 +3,7 @@
 <head><meta charset="UTF-8"><title>table_pos_tests.html</title></head>
 <body>
 
-<p>&nbsp;</p><style>
+<style>
 .huxtable {
   border-collapse: collapse;
   border: 0px;
@@ -27,7 +27,7 @@
   page-break-inside: avoid;
 }
 </style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: 0%; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: 0%; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: left;">Table 1: position="left"</caption><col><tbody>
 <tr>
 <td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">position=left</td></tr>
@@ -35,31 +35,7 @@
 </table>
 
 
-<p>&nbsp;</p><style>
-.huxtable {
-  border-collapse: collapse;
-  border: 0px;
-  margin-bottom: 2em;
-  margin-top: 2em;
-}
-.huxtable-cell {
-  vertical-align: top;
-  text-align: left;
-  white-space: normal;
-  border-style: solid;
-  border-width: 0pt;
-  padding: 6pt;
-  font-weight: normal;
-}
-.huxtable-header {
-  font-weight: bold;
-}
-.huxtable tr {
-  break-inside: avoid;
-  page-break-inside: avoid;
-}
-</style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Table 2: position="center"</caption><col><tbody>
 <tr>
 <td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">position=center</td></tr>
@@ -67,31 +43,7 @@
 </table>
 
 
-<p>&nbsp;</p><style>
-.huxtable {
-  border-collapse: collapse;
-  border: 0px;
-  margin-bottom: 2em;
-  margin-top: 2em;
-}
-.huxtable-cell {
-  vertical-align: top;
-  text-align: left;
-  white-space: normal;
-  border-style: solid;
-  border-width: 0pt;
-  padding: 6pt;
-  font-weight: normal;
-}
-.huxtable-header {
-  font-weight: bold;
-}
-.huxtable tr {
-  break-inside: avoid;
-  page-break-inside: avoid;
-}
-</style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: 0%;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: 0%;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: right;">Table 3: position="right"</caption><col><tbody>
 <tr>
 <td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">position=right</td></tr>

--- a/tests/testthat/_snaps/text/validate-outputs/table_pos_tests.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/table_pos_tests.tex
@@ -1,5 +1,9 @@
 \documentclass{article}
 \usepackage{array}
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -22,11 +26,6 @@
 
 \begin{document}
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \begin{raggedright}
@@ -54,11 +53,6 @@
 
 
 
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
-
 \begin{table}[ht]
 \begin{centerbox}
 \begin{threeparttable}
@@ -84,11 +78,6 @@
 
 
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \begin{raggedleft}

--- a/tests/testthat/_snaps/text/validate-outputs/table_pos_tests.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/table_pos_tests.tex
@@ -1,9 +1,5 @@
 \documentclass{article}
 \usepackage{array}
-\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -21,6 +17,10 @@
 % These are LaTeX packages. You can install them using your LaTex management software,
 % or by running `huxtable::install_latex_dependencies()` from within R.
 % Other packages may be required if you use non-standard tabulars (e.g. tabulary).
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \pagenumbering{gobble}
 

--- a/tests/testthat/_snaps/text/validate-outputs/table_width_tests.html
+++ b/tests/testthat/_snaps/text/validate-outputs/table_width_tests.html
@@ -3,7 +3,7 @@
 <head><meta charset="UTF-8"><title>table_width_tests.html</title></head>
 <body>
 
-<p>&nbsp;</p><style>
+<style>
 .huxtable {
   border-collapse: collapse;
   border: 0px;
@@ -27,7 +27,7 @@
   page-break-inside: avoid;
 }
 </style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="width: 30%; margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="width: 30%; margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Table 1: width=0.3 (30%)</caption><col><tbody>
 <tr>
 <td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">width=0.3</td></tr>
@@ -35,31 +35,7 @@
 </table>
 
 
-<p>&nbsp;</p><style>
-.huxtable {
-  border-collapse: collapse;
-  border: 0px;
-  margin-bottom: 2em;
-  margin-top: 2em;
-}
-.huxtable-cell {
-  vertical-align: top;
-  text-align: left;
-  white-space: normal;
-  border-style: solid;
-  border-width: 0pt;
-  padding: 6pt;
-  font-weight: normal;
-}
-.huxtable-header {
-  font-weight: bold;
-}
-.huxtable tr {
-  break-inside: avoid;
-  page-break-inside: avoid;
-}
-</style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="width: 60%; margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="width: 60%; margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Table 2: width=0.6 (60%)</caption><col><tbody>
 <tr>
 <td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">width=0.6</td></tr>
@@ -67,31 +43,7 @@
 </table>
 
 
-<p>&nbsp;</p><style>
-.huxtable {
-  border-collapse: collapse;
-  border: 0px;
-  margin-bottom: 2em;
-  margin-top: 2em;
-}
-.huxtable-cell {
-  vertical-align: top;
-  text-align: left;
-  white-space: normal;
-  border-style: solid;
-  border-width: 0pt;
-  padding: 6pt;
-  font-weight: normal;
-}
-.huxtable-header {
-  font-weight: bold;
-}
-.huxtable tr {
-  break-inside: avoid;
-  page-break-inside: avoid;
-}
-</style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="width: 90%; margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="width: 90%; margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Table 3: width=0.9 (90%)</caption><col><tbody>
 <tr>
 <td class="huxtable-cell" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;">width=0.9</td></tr>

--- a/tests/testthat/_snaps/text/validate-outputs/table_width_tests.html
+++ b/tests/testthat/_snaps/text/validate-outputs/table_width_tests.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>table_width_tests.html</title></head>
-<body>
-
+<head><meta charset="UTF-8"><title>table_width_tests.html</title>
 <style>
 .huxtable {
   border-collapse: collapse;
@@ -27,6 +25,9 @@
   page-break-inside: avoid;
 }
 </style>
+</head>
+<body>
+
 <p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="width: 30%; margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Table 1: width=0.3 (30%)</caption><col><tbody>
 <tr>

--- a/tests/testthat/_snaps/text/validate-outputs/table_width_tests.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/table_width_tests.tex
@@ -1,5 +1,9 @@
 \documentclass{article}
 \usepackage{array}
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -22,11 +26,6 @@
 
 \begin{document}
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \begin{centerbox}
@@ -54,11 +53,6 @@
 
 
 
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
-
 \begin{table}[ht]
 \begin{centerbox}
 \begin{threeparttable}
@@ -84,11 +78,6 @@
 
 
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \begin{centerbox}

--- a/tests/testthat/_snaps/text/validate-outputs/table_width_tests.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/table_width_tests.tex
@@ -1,9 +1,5 @@
 \documentclass{article}
 \usepackage{array}
-\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -21,6 +17,10 @@
 % These are LaTeX packages. You can install them using your LaTex management software,
 % or by running `huxtable::install_latex_dependencies()` from within R.
 % Other packages may be required if you use non-standard tabulars (e.g. tabulary).
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \pagenumbering{gobble}
 

--- a/tests/testthat/_snaps/text/validate-outputs/text_alignment.html
+++ b/tests/testthat/_snaps/text/validate-outputs/text_alignment.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>text_alignment.html</title></head>
-<body>
-
+<head><meta charset="UTF-8"><title>text_alignment.html</title>
 <style>
 .huxtable {
   border-collapse: collapse;
@@ -27,6 +25,9 @@
   page-break-inside: avoid;
 }
 </style>
+</head>
+<body>
+
 <p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="width: 100%; margin-left: auto; margin-right: auto; height: 50%;  break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Text alignment: align=(left, center, right) × valign=(top, middle, bottom)</caption><col style="width: 33%"><col style="width: 33%"><col style="width: 33%"><thead>
 <tr style="height: 10%;">

--- a/tests/testthat/_snaps/text/validate-outputs/text_alignment.html
+++ b/tests/testthat/_snaps/text/validate-outputs/text_alignment.html
@@ -3,7 +3,7 @@
 <head><meta charset="UTF-8"><title>text_alignment.html</title></head>
 <body>
 
-<p>&nbsp;</p><style>
+<style>
 .huxtable {
   border-collapse: collapse;
   border: 0px;
@@ -27,7 +27,7 @@
   page-break-inside: avoid;
 }
 </style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="width: 100%; margin-left: auto; margin-right: auto; height: 50%;  break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="width: 100%; margin-left: auto; margin-right: auto; height: 50%;  break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Text alignment: align=(left, center, right) × valign=(top, middle, bottom)</caption><col style="width: 33%"><col style="width: 33%"><col style="width: 33%"><thead>
 <tr style="height: 10%;">
 <th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Left</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Center</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Right</th></tr>

--- a/tests/testthat/_snaps/text/validate-outputs/text_alignment.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/text_alignment.tex
@@ -1,5 +1,9 @@
 \documentclass{article}
 \usepackage{array}
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -22,11 +26,6 @@
 
 \begin{document}
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \begin{centerbox}

--- a/tests/testthat/_snaps/text/validate-outputs/text_alignment.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/text_alignment.tex
@@ -1,9 +1,5 @@
 \documentclass{article}
 \usepackage{array}
-\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -21,6 +17,10 @@
 % These are LaTeX packages. You can install them using your LaTex management software,
 % or by running `huxtable::install_latex_dependencies()` from within R.
 % Other packages may be required if you use non-standard tabulars (e.g. tabulary).
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \pagenumbering{gobble}
 

--- a/tests/testthat/_snaps/text/validate-outputs/text_effects.html
+++ b/tests/testthat/_snaps/text/validate-outputs/text_effects.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>text_effects.html</title></head>
-<body>
-
+<head><meta charset="UTF-8"><title>text_effects.html</title>
 <style>
 .huxtable {
   border-collapse: collapse;
@@ -27,6 +25,9 @@
   page-break-inside: avoid;
 }
 </style>
+</head>
+<body>
+
 <p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="width: 80%; margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Text effects: wrap (TRUE vs FALSE), rotation=90, padding=10px</caption><col style="width: 25%"><col style="width: 25%"><col style="width: 20%"><col style="width: 30%"><thead>
 <tr style="height: 20%;">

--- a/tests/testthat/_snaps/text/validate-outputs/text_effects.html
+++ b/tests/testthat/_snaps/text/validate-outputs/text_effects.html
@@ -3,7 +3,7 @@
 <head><meta charset="UTF-8"><title>text_effects.html</title></head>
 <body>
 
-<p>&nbsp;</p><style>
+<style>
 .huxtable {
   border-collapse: collapse;
   border: 0px;
@@ -27,7 +27,7 @@
   page-break-inside: avoid;
 }
 </style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="width: 80%; margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="width: 80%; margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Text effects: wrap (TRUE vs FALSE), rotation=90, padding=10px</caption><col style="width: 25%"><col style="width: 25%"><col style="width: 20%"><col style="width: 30%"><thead>
 <tr style="height: 20%;">
 <th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Wrap 1</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Wrap 2</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Rotation</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Padding</th></tr>

--- a/tests/testthat/_snaps/text/validate-outputs/text_effects.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/text_effects.tex
@@ -1,5 +1,9 @@
 \documentclass{article}
 \usepackage{array}
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -22,11 +26,6 @@
 
 \begin{document}
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \begin{centerbox}

--- a/tests/testthat/_snaps/text/validate-outputs/text_effects.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/text_effects.tex
@@ -1,9 +1,5 @@
 \documentclass{article}
 \usepackage{array}
-\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -21,6 +17,10 @@
 % These are LaTeX packages. You can install them using your LaTex management software,
 % or by running `huxtable::install_latex_dependencies()` from within R.
 % Other packages may be required if you use non-standard tabulars (e.g. tabulary).
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \pagenumbering{gobble}
 

--- a/tests/testthat/_snaps/text/validate-outputs/text_properties.html
+++ b/tests/testthat/_snaps/text/validate-outputs/text_properties.html
@@ -3,7 +3,7 @@
 <head><meta charset="UTF-8"><title>text_properties.html</title></head>
 <body>
 
-<p>&nbsp;</p><style>
+<style>
 .huxtable {
   border-collapse: collapse;
   border: 0px;
@@ -27,7 +27,7 @@
   page-break-inside: avoid;
 }
 </style>
- <table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
+<p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Text formatting: bold, italic, font, font_size, markdown, text_color, background_color</caption><col><col><col><thead>
 <tr>
 <th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Property</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Normal</th><th class="huxtable-cell huxtable-header" style="border-style: solid solid solid solid; border-width: 1pt 1pt 1pt 1pt;      font-weight: normal;">Styled</th></tr>

--- a/tests/testthat/_snaps/text/validate-outputs/text_properties.html
+++ b/tests/testthat/_snaps/text/validate-outputs/text_properties.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>text_properties.html</title></head>
-<body>
-
+<head><meta charset="UTF-8"><title>text_properties.html</title>
 <style>
 .huxtable {
   border-collapse: collapse;
@@ -27,6 +25,9 @@
   page-break-inside: avoid;
 }
 </style>
+</head>
+<body>
+
 <p>&nbsp;</p><table class="huxtable" data-quarto-disable-processing="true"  style="margin-left: auto; margin-right: auto;   break-inside: avoid; page-break-inside: avoid;">
 <caption style="caption-side: top; text-align: center;">Text formatting: bold, italic, font, font_size, markdown, text_color, background_color</caption><col><col><col><thead>
 <tr>

--- a/tests/testthat/_snaps/text/validate-outputs/text_properties.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/text_properties.tex
@@ -1,5 +1,9 @@
 \documentclass{article}
 \usepackage{array}
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -22,11 +26,6 @@
 
 \begin{document}
 
-
-  \providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-  \providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-  \providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-  \providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \begin{table}[ht]
 \begin{centerbox}

--- a/tests/testthat/_snaps/text/validate-outputs/text_properties.tex
+++ b/tests/testthat/_snaps/text/validate-outputs/text_properties.tex
@@ -1,9 +1,5 @@
 \documentclass{article}
 \usepackage{array}
-\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
-\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
-\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
-\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 \usepackage{caption}
 \usepackage{graphicx}
 \usepackage{siunitx}
@@ -21,6 +17,10 @@
 % These are LaTeX packages. You can install them using your LaTex management software,
 % or by running `huxtable::install_latex_dependencies()` from within R.
 % Other packages may be required if you use non-standard tabulars (e.g. tabulary).
+\providecommand{\huxb}[2]{\arrayrulecolor[RGB]{#1}\global\arrayrulewidth=#2pt}
+\providecommand{\huxvb}[2]{\color[RGB]{#1}\vrule width #2pt}
+\providecommand{\huxtpad}[1]{\rule{0pt}{#1}}
+\providecommand{\huxbpad}[1]{\rule[-#1]{0pt}{#1}}
 
 \pagenumbering{gobble}
 

--- a/tests/testthat/test-as-html.R
+++ b/tests/testthat/test-as-html.R
@@ -2,5 +2,6 @@ test_that("as_html returns htmltools tag", {
   ht <- hux(a = 1:2, b = 3:4)
   tag <- as_html(ht)
   expect_s3_class(tag, "html")
-  expect_identical(as.character(tag), to_html(ht))
+  expect_identical(as.character(tag), to_html(ht, dependencies = FALSE))
+  expect_s3_class(htmltools::htmlDependencies(tag)[[1]], "html_dependency")
 })

--- a/tests/testthat/test-html-builders.R
+++ b/tests/testthat/test-html-builders.R
@@ -17,11 +17,7 @@ test_that("builders reproduce to_html output", {
 test_that("HTML dependencies can be included or omitted", {
   ht <- hux(a = 1)
   expect_match(to_html(ht), "<style>", fixed = TRUE)
-  expect_false(grepl("<style>", to_html(ht, dependencies = FALSE), fixed = TRUE))
-  expect_true(any(grepl("<style>", capture.output(print_html(ht)), fixed = TRUE)))
-  expect_false(any(grepl(
-    "<style>", capture.output(print_html(ht, dependencies = FALSE)), fixed = TRUE
-  )))
+  expect_no_match(to_html(ht, dependencies = FALSE), "<style>", fixed = TRUE)
 })
 
 

--- a/tests/testthat/test-html-builders.R
+++ b/tests/testthat/test-html-builders.R
@@ -3,7 +3,7 @@ local_edition(3)
 test_that("builders reproduce to_html output", {
   ht <- hux(a = 1:2, b = 3:4)
   expect_identical(
-    to_html(ht),
+    to_html(ht, dependencies = FALSE),
     paste0(
       huxtable:::build_table_style(ht),
       huxtable:::build_colgroup(ht),
@@ -12,6 +12,18 @@ test_that("builders reproduce to_html output", {
     )
   )
 })
+
+
+test_that("HTML dependencies can be included or omitted", {
+  ht <- hux(a = 1)
+  expect_match(to_html(ht), "<style>", fixed = TRUE)
+  expect_false(grepl("<style>", to_html(ht, dependencies = FALSE), fixed = TRUE))
+  expect_true(any(grepl("<style>", capture.output(print_html(ht)), fixed = TRUE)))
+  expect_false(any(grepl(
+    "<style>", capture.output(print_html(ht, dependencies = FALSE)), fixed = TRUE
+  )))
+})
+
 
 test_that("build_cell_html returns correct dimensions", {
   ht <- hux(a = 1:2, b = 3:4)

--- a/tests/testthat/test-knit-print.R
+++ b/tests/testthat/test-knit-print.R
@@ -51,6 +51,33 @@ test_that("knitr_output_format overrides default output format in knit_print", {
 })
 
 
+test_that("HTML and LaTeX dependencies are registered with knitr", {
+  ht <- hux(a = 1)
+  old_options <- options(huxtable.knitr_output_format = "html")
+  on.exit(options(old_options))
+
+  html <- knitr::knit_print(ht)
+  expect_false(grepl("<style>", html, fixed = TRUE))
+  html_meta <- attr(html, "knit_meta")
+  expect_length(html_meta, 1)
+  expect_s3_class(html_meta[[1]], "html_dependency")
+  expect_equal(html_meta[[1]]$name, "huxtable")
+  expect_equal(html_meta[[1]]$stylesheet, "huxtable.css")
+  css_path <- system.file("huxtable", "huxtable.css", package = "huxtable")
+  expect_true(file.exists(css_path))
+  expect_true(any(grepl(".huxtable-cell", readLines(css_path), fixed = TRUE)))
+
+  options(huxtable.knitr_output_format = "latex")
+  latex <- knitr::knit_print(ht)
+  expect_false(grepl("\\providecommand", latex, fixed = TRUE))
+  array_dep <- attr(latex, "knit_meta")[[1]]
+  expect_equal(array_dep$name, "array")
+  expect_true(any(grepl(
+    "\\providecommand{\\huxb}", array_dep$extra_lines, fixed = TRUE
+  )))
+})
+
+
 test_that("knit_print warns if output format is weird", {
   oo <- options(huxtable.knitr_output_format = "weirdness")
   ht <- hux(a = 1)

--- a/tests/testthat/test-latex-dependencies.R
+++ b/tests/testthat/test-latex-dependencies.R
@@ -21,6 +21,7 @@ test_that("install/report_latex_dependencies", {
     as_string = TRUE
   ))
   expect_match(package_str, "\\\\usepackage\\{array\\}")
+  expect_match(package_str, "\\\\providecommand\\{\\\\huxb\\}")
 })
 
 

--- a/tests/testthat/test-latex-dependencies.R
+++ b/tests/testthat/test-latex-dependencies.R
@@ -21,7 +21,7 @@ test_that("install/report_latex_dependencies", {
     as_string = TRUE
   ))
   expect_match(package_str, "\\\\usepackage\\{array\\}")
-  expect_match(package_str, "\\\\providecommand\\{\\\\huxb\\}")
+  expect_no_match(package_str, "\\\\providecommand\\{\\\\huxb\\}")
 })
 
 

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -213,6 +213,21 @@ test_that("Bugfix: print_html doesn't duplicate rows", {
 })
 
 
+test_that("LaTeX dependencies can be included or omitted", {
+  ht <- hux(a = 1)
+  expect_match(to_latex(ht), "\\providecommand{\\huxb}", fixed = TRUE)
+  expect_false(grepl(
+    "\\providecommand", to_latex(ht, dependencies = FALSE), fixed = TRUE
+  ))
+  expect_true(any(grepl(
+    "\\providecommand", capture.output(print_latex(ht)), fixed = TRUE
+  )))
+  expect_false(any(grepl(
+    "\\providecommand", capture.output(print_latex(ht, dependencies = FALSE)), fixed = TRUE
+  )))
+})
+
+
 test_that("format.huxtable works", {
   ht <- hux(a = 1:3, b = 1:3)
   for (output in c("latex", "html", "md", "screen", "typst")) {

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -216,15 +216,7 @@ test_that("Bugfix: print_html doesn't duplicate rows", {
 test_that("LaTeX dependencies can be included or omitted", {
   ht <- hux(a = 1)
   expect_match(to_latex(ht), "\\providecommand{\\huxb}", fixed = TRUE)
-  expect_false(grepl(
-    "\\providecommand", to_latex(ht, dependencies = FALSE), fixed = TRUE
-  ))
-  expect_true(any(grepl(
-    "\\providecommand", capture.output(print_latex(ht)), fixed = TRUE
-  )))
-  expect_false(any(grepl(
-    "\\providecommand", capture.output(print_latex(ht, dependencies = FALSE)), fixed = TRUE
-  )))
+  expect_no_match(to_latex(ht, dependencies = FALSE), "\\providecommand", fixed = TRUE)
 })
 
 

--- a/tests/testthat/test-quick-output.R
+++ b/tests/testthat/test-quick-output.R
@@ -61,6 +61,8 @@ test_that("Quick HTML and LaTeX output includes dependencies once", {
   html <- paste(readLines(html_file, warn = FALSE), collapse = "\n")
   html_matches <- gregexpr("border-collapse: collapse", html, fixed = TRUE)[[1]]
   expect_length(html_matches[html_matches >= 0], 1)
+  expect_lt(regexpr("<style>", html, fixed = TRUE), regexpr("</head>", html, fixed = TRUE))
+  expect_lt(regexpr("</style>", html, fixed = TRUE), regexpr("<body>", html, fixed = TRUE))
 
   latex_file <- tempfile(fileext = ".tex")
   quick_latex(first, second, file = latex_file, open = FALSE)

--- a/tests/testthat/test-quick-output.R
+++ b/tests/testthat/test-quick-output.R
@@ -52,6 +52,24 @@ test_that("Quick output functions create files", {
 })
 
 
+test_that("Quick HTML and LaTeX output includes dependencies once", {
+  first <- hux(a = 1)
+  second <- hux(b = 2)
+
+  html_file <- tempfile(fileext = ".html")
+  quick_html(first, second, file = html_file, open = FALSE)
+  html <- paste(readLines(html_file, warn = FALSE), collapse = "\n")
+  html_matches <- gregexpr("border-collapse: collapse", html, fixed = TRUE)[[1]]
+  expect_length(html_matches[html_matches >= 0], 1)
+
+  latex_file <- tempfile(fileext = ".tex")
+  quick_latex(first, second, file = latex_file, open = FALSE)
+  latex <- paste(readLines(latex_file, warn = FALSE), collapse = "\n")
+  latex_matches <- gregexpr("\\providecommand{\\huxb}[2]", latex, fixed = TRUE)[[1]]
+  expect_length(latex_matches[latex_matches >= 0], 1)
+})
+
+
 test_that("quick_latex can be compiled", {
   skip_on_appveyor() # no pdflatex
   skip_on_ci() # trouble on github


### PR DESCRIPTION
## Summary
- register huxtable CSS as a package-backed htmltools dependency in knitr, R Markdown, and Quarto
- register huxtable LaTeX command definitions with the existing LaTeX dependency metadata
- add dependencies = TRUE to HTML and LaTeX conversion and print APIs, with opt-out support
- emit dependencies once in standalone quick HTML and LaTeX documents
- document the rendering architecture and update output snapshots

## Testing
- full non-fuzz test suite, including end-to-end R Markdown, Bookdown, Quarto, Word, Typst, and quick-output tests
- direct Quarto 1.7.33 HTML and PDF renders with two tables: one CSS block / one LaTeX macro block
- direct R Markdown HTML and PDF renders with two tables: one CSS block / one LaTeX macro block
- visual inspection of the compiled PDF for borders, fills, captions, clipping, and overlap
- R CMD check: 0 errors; only pre-existing vignette warnings and tmp.log / unused-import notes remain