### PR TITLE
Fix Quarto caption and label precedence

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,9 @@
   once. Outside those documents, `to_html()`, `print_html()`, `to_latex()` and
   `print_latex()` include them by default; use `dependencies = FALSE` to omit
   them.
+* Bugfix: Quarto table captions and labels now override captions and labels set
+  on a huxtable in HTML, PDF, Typst and Word output. Huxtable warns when both
+  mechanisms explicitly set the same property.
   
 # huxtable 5.8.0
 

--- a/R/captions.R
+++ b/R/captions.R
@@ -61,15 +61,20 @@ use_bookdown_style_captions <- function() {
 #'
 #' @param ht A huxtable.
 #' @param format Output format.
-#' @return A list with three elements:
+#' @return A list with five elements:
 #' * `text`: caption text, including bookdown label syntax when required, or
 #'   `NA` when there is no caption;
 #' * `label`: the explicit or automatically generated table label, or `NA`;
-#' * `label_in_caption`: whether `text` contains the label in bookdown syntax.
+#' * `label_in_caption`: whether `text` contains the label in bookdown syntax;
+#' * `quarto_caption`: whether Quarto owns the table caption;
+#' * `quarto_label`: whether Quarto owns the table label.
 #' @noRd
-resolve_caption <- function(ht, format = c("html", "latex", "md", "typst")) {
+resolve_caption <- function(ht, format = c("html", "latex", "md", "typst", "docx")) {
   format <- match.arg(format)
+  cap <- caption(ht)
   lab <- label(ht)
+  explicit_cap <- !is.na(cap) && nzchar(cap)
+  explicit_lab <- !is.na(lab) && nzchar(lab)
 
   has_knitr <- requireNamespace("knitr", quietly = TRUE)
   chunk_options <- if (has_knitr) knitr::opts_current$get() else NULL
@@ -77,6 +82,28 @@ resolve_caption <- function(ht, format = c("html", "latex", "md", "typst")) {
   if (length(chunk_label) > 0 && grepl("^unnamed-chunk", chunk_label)) {
     chunk_label <- NULL
   }
+
+  is_quarto <- using_quarto()
+  quarto_caption <- is_quarto &&
+    (!is.null(chunk_options[["tbl-cap"]]) || !is.null(chunk_options[["tbl-subcap"]]))
+  quarto_label <- is_quarto &&
+    !is.null(chunk_label) &&
+    nzchar(chunk_label) &&
+    (quarto_caption || grepl("^tbl-", chunk_label))
+
+  conflicts <- character()
+  if (quarto_caption && explicit_cap) conflicts <- c(conflicts, "caption")
+  if (quarto_label && explicit_lab) conflicts <- c(conflicts, "label")
+  if (length(conflicts) > 0) {
+    fields <- paste(conflicts, collapse = " and ")
+    warning(
+      "Quarto table options override the huxtable ", fields, ".",
+      call. = FALSE
+    )
+  }
+
+  if (quarto_caption) cap <- NA_character_
+  if (quarto_label) lab <- NA_character_
 
   same_chunk <- identical(chunk_label, huxtable_env$autolabel_chunk$label) &&
     rlang::is_reference(chunk_options, huxtable_env$autolabel_chunk$options)
@@ -95,6 +122,7 @@ resolve_caption <- function(ht, format = c("html", "latex", "md", "typst")) {
   if (is.null(used_labels)) used_labels <- character()
 
   if (is.na(lab) &&
+    !quarto_label &&
     getOption("huxtable.autolabel", TRUE) &&
     !is.null(chunk_label)) {
     base_label <- paste0("tab:", chunk_label)
@@ -106,35 +134,15 @@ resolve_caption <- function(ht, format = c("html", "latex", "md", "typst")) {
     }
   }
 
-  if (!is.null(chunk_label) &&
-    using_quarto("1.4") &&
-    getOption(
-      "huxtable.knitr_output_format",
-      guess_knitr_output_format()
-    ) == "latex"
-  ) {
-    msg <- paste(
-      "quarto cell labels do not work with huxtable in TeX for quarto ",
-      "version 1.4 or above.",
-      "Use huxtable labels instead via `label()` or `set_label()`.",
-      "See `?huxtable-FAQ` for more details.",
-      sep = "\n"
-    )
-    if (grepl("^tbl-", chunk_label)) {
-      stop(msg)
-    } else {
-      warning(msg)
-    }
-  }
-
   if (!is.null(chunk_label) && !is.na(lab) && nzchar(lab)) {
     huxtable_env$autolabel_cache[[chunk_label]] <- unique(c(used_labels, lab))
   }
 
-  cap <- caption(ht)
   label_in_caption <- FALSE
 
-  if (!is.na(lab) && nzchar(lab) && use_bookdown_style_captions()) {
+  if (!is.na(lab) && nzchar(lab) &&
+    format != "docx" &&
+    use_bookdown_style_captions()) {
     bookdown_label <- if (grepl("^tab:", lab)) lab else paste0("tab:", lab)
     # Bookdown needs a caption, even an empty one, to carry the label.
     if (is.na(cap)) cap <- ""
@@ -146,5 +154,11 @@ resolve_caption <- function(ht, format = c("html", "latex", "md", "typst")) {
     label_in_caption <- TRUE
   }
 
-  list(text = cap, label = lab, label_in_caption = label_in_caption)
+  list(
+    text = cap,
+    label = lab,
+    label_in_caption = label_in_caption,
+    quarto_caption = quarto_caption,
+    quarto_label = quarto_label
+  )
 }

--- a/R/captions.R
+++ b/R/captions.R
@@ -61,13 +61,11 @@ use_bookdown_style_captions <- function() {
 #'
 #' @param ht A huxtable.
 #' @param format Output format.
-#' @return A list with five elements:
+#' @return A list with three elements:
 #' * `text`: caption text, including bookdown label syntax when required, or
 #'   `NA` when there is no caption;
 #' * `label`: the explicit or automatically generated table label, or `NA`;
-#' * `label_in_caption`: whether `text` contains the label in bookdown syntax;
-#' * `quarto_caption`: whether Quarto owns the table caption;
-#' * `quarto_label`: whether Quarto owns the table label.
+#' * `label_in_caption`: whether `text` contains the label in bookdown syntax.
 #' @noRd
 resolve_caption <- function(ht, format = c("html", "latex", "md", "typst", "docx")) {
   format <- match.arg(format)
@@ -154,11 +152,5 @@ resolve_caption <- function(ht, format = c("html", "latex", "md", "typst", "docx
     label_in_caption <- TRUE
   }
 
-  list(
-    text = cap,
-    label = lab,
-    label_in_caption = label_in_caption,
-    quarto_caption = quarto_caption,
-    quarto_label = quarto_label
-  )
+  list(text = cap, label = lab, label_in_caption = label_in_caption)
 }

--- a/R/flextable.R
+++ b/R/flextable.R
@@ -182,9 +182,10 @@ as_flextable.huxtable <- function(x, colnames_to_header = FALSE, ...) {
   }
 
   # set caption
-  if (!is.null(caption(x)) & !is.na(caption(x))) {
+  caption_data <- resolve_caption(x, "docx")
+  if (!is.null(caption_data$text) && !is.na(caption_data$text)) {
     if (flextable_version >= "0.5.5") {
-      ft <- flextable::set_caption(ft, caption(x))
+      ft <- flextable::set_caption(ft, caption_data$text)
     } else {
       message(
         "Use of table captions requires \"flextable\" package version >= 0.5.5.",

--- a/R/latex.R
+++ b/R/latex.R
@@ -127,6 +127,11 @@ build_latex_caption <- function(ht, longtable = FALSE) {
   lab <- caption_data$label
   cap <- caption_data$text
 
+  if (is.na(cap) && is.na(lab) &&
+    (caption_data$quarto_caption || caption_data$quarto_label)) {
+    return("")
+  }
+
   if (is.na(cap)) {
     cap <- ""
   } else {
@@ -160,7 +165,8 @@ build_latex_caption <- function(ht, longtable = FALSE) {
 
   lab <- if (is.na(lab) || caption_data$label_in_caption) "" else sprintf("\\label{%s}\n", lab)
   cap <- paste(cap, lab)
-  if (using_quarto(min_version = "1.4") &&
+  if (nzchar(trimws(cap)) &&
+    using_quarto(min_version = "1.4") &&
     getOption(
       "huxtable.knitr_output_format",
       guess_knitr_output_format()

--- a/R/latex.R
+++ b/R/latex.R
@@ -127,10 +127,7 @@ build_latex_caption <- function(ht, longtable = FALSE) {
   lab <- caption_data$label
   cap <- caption_data$text
 
-  if (is.na(cap) && is.na(lab) &&
-    (caption_data$quarto_caption || caption_data$quarto_label)) {
-    return("")
-  }
+  if (is.na(cap) && is.na(lab)) return("")
 
   if (is.na(cap)) {
     cap <- ""

--- a/R/package-docs.R
+++ b/R/package-docs.R
@@ -207,31 +207,22 @@
 #'
 #' * How do I refer to tables in quarto?
 #'
-#'   In quarto versions up to 1.3, or when compiling to HTML and
-#'   other formats, simply use quarto cell labels
-#'   like `label: tbl-foo` and refer to them via `@tbl-foo`.
-#'
-#'   In quarto versions 1.4 and above, when compiling to PDF,
-#'   quarto cross-referencing no longer works.
-#'   Instead, set labels within huxtable using [label()] or
-#'   [set_label()] and refer to them with TeX-only referencing using
-#'   `\ref{label}`. You must also set a caption.
-#'
-#'   Here's an example:
+#'   Set the Quarto `label` and `tbl-cap` cell options, then use Quarto's
+#'   `@tbl-foo` syntax. This works across Quarto output formats:
 #'
 #'   ````
-#'   A reference to Table \ref{tbl-jams}.
+#'   See @tbl-jams.
 #'
 #'   ```{r}
-#'   label(jams) <- "tbl-jams"
-#'   caption(jams) <- "Some jams"
+#'   #| label: tbl-jams
+#'   #| tbl-cap: "Some jams"
 #'   jams
 #'   ```
 #'   ````
 #'
-#'  If you really need cross-referencing for both PDF and other output
-#'  formats, either downgrade to quarto 1.3, use a different package,
-#'  or write code to emit appropriate references.
+#'   Quarto captions and table labels override values set with [caption()] and
+#'   [label()]. Huxtable warns if both mechanisms explicitly set the same
+#'   property.
 #'
 #' * I called `library(huxtable)` and now my `data.table` objects are getting
 #'   printed!

--- a/R/properties-table.R
+++ b/R/properties-table.R
@@ -299,8 +299,8 @@ set_breakable <- function(ht, value) {
 #' @details
 #' Captions are not escaped. See the example for a workaround.
 #'
-#' Table captions set via the Quarto `tbl-cap` chunk option override captions set
-#' by this mechanism.
+#' Table captions set via the Quarto `tbl-cap` or `tbl-subcap` chunk options
+#' override captions set by this mechanism. A warning is issued if both are set.
 #'
 #' @family caption properties
 #'
@@ -428,6 +428,9 @@ set_table_environment <- function(ht, value) {
 #' with `"tab:"`; if it doesn't, the `"tab:"` prefix will be added
 #' automatically. To turn off this behaviour, set
 #' `options(huxtable.bookdown = FALSE)`.
+#'
+#' Quarto table labels override labels set by this mechanism. A warning is
+#' issued if both are set.
 #'
 #' @examples
 #' set_label(jams, "tab:mytable")

--- a/design.md
+++ b/design.md
@@ -80,11 +80,13 @@ command definitions by default so their output remains standalone.
 
 Caption and label behavior shared by the renderers is implemented in
 `R/captions.R`. `resolve_caption()` returns caption text, the resolved label,
-and whether bookdown syntax embedded that label in the caption. LaTeX, HTML,
-Markdown and Typst consume this result, while each renderer remains responsible
-for its own escaping, sizing and output markup. Simpler backends such as screen,
-RTF and Excel use the raw caption property and the shared horizontal and
-vertical position helpers.
+whether bookdown syntax embedded that label in the caption, and whether Quarto
+owns either property. Quarto cell options take precedence independently over
+explicit huxtable captions and labels; conflicts produce a warning. LaTeX,
+HTML, Markdown, Typst and Word consume the resolved values, while each renderer
+remains responsible for its own escaping, sizing and output markup. Simpler
+backends such as screen, RTF and Excel use the raw caption property and the
+shared horizontal and vertical position helpers.
 
 Automatic labels are based on the knitr chunk label. Labels already emitted in
 the current chunk are stored in a package-internal cache keyed by the chunk

--- a/design.md
+++ b/design.md
@@ -80,13 +80,13 @@ command definitions by default so their output remains standalone.
 
 Caption and label behavior shared by the renderers is implemented in
 `R/captions.R`. `resolve_caption()` returns caption text, the resolved label,
-whether bookdown syntax embedded that label in the caption, and whether Quarto
-owns either property. Quarto cell options take precedence independently over
-explicit huxtable captions and labels; conflicts produce a warning. LaTeX,
-HTML, Markdown, Typst and Word consume the resolved values, while each renderer
-remains responsible for its own escaping, sizing and output markup. Simpler
-backends such as screen, RTF and Excel use the raw caption property and the
-shared horizontal and vertical position helpers.
+and whether bookdown syntax embedded that label in the caption. It internally
+detects whether Quarto owns either property. Quarto cell options take precedence
+independently over explicit huxtable captions and labels; conflicts produce a
+warning. LaTeX, HTML, Markdown, Typst and Word consume the resolved values,
+while each renderer remains responsible for its own escaping, sizing and output
+markup. Simpler backends such as screen, RTF and Excel use the raw caption
+property and the shared horizontal and vertical position helpers.
 
 Automatic labels are based on the knitr chunk label. Labels already emitted in
 the current chunk are stored in a package-internal cache keyed by the chunk

--- a/man/caption.Rd
+++ b/man/caption.Rd
@@ -28,8 +28,8 @@ with \code{\link[=caption_pos]{caption_pos()}}.
 \details{
 Captions are not escaped. See the example for a workaround.
 
-Table captions set via the Quarto \code{tbl-cap} chunk option override captions set
-by this mechanism.
+Table captions set via the Quarto \code{tbl-cap} or \code{tbl-subcap} chunk options
+override captions set by this mechanism. A warning is issued if both are set.
 }
 \examples{
 

--- a/man/huxtable-FAQ.Rd
+++ b/man/huxtable-FAQ.Rd
@@ -77,32 +77,21 @@ set the label using \code{\link[=label]{label()}}, then in markdown text do e.g.
 }\if{html}{\out{</div>}}
 \item How do I refer to tables in quarto?
 
-In quarto versions up to 1.3, or when compiling to HTML and
-other formats, simply use quarto cell labels
-like \code{label: tbl-foo} and refer to them via \verb{@tbl-foo}.
+Set the Quarto \code{label} and \code{tbl-cap} cell options, then use Quarto's
+\verb{@tbl-foo} syntax. This works across Quarto output formats:
 
-In quarto versions 1.4 and above, when compiling to PDF,
-quarto cross-referencing no longer works.
-Instead, set labels within huxtable using \code{\link[=label]{label()}} or
-\code{\link[=set_label]{set_label()}} and refer to them with TeX-only referencing using
-\verb{\\ref\{label\}}. You must also set a caption.
-
-Here's an example:
-
-\if{html}{\out{<div class="sourceCode">}}\preformatted{A reference to Table \\ref\{tbl-jams\}.
+\if{html}{\out{<div class="sourceCode">}}\preformatted{See @tbl-jams.
 
 ```\{r\}
-label(jams) <- "tbl-jams"
-caption(jams) <- "Some jams"
+#| label: tbl-jams
+#| tbl-cap: "Some jams"
 jams
 ```
 }\if{html}{\out{</div>}}
-}
 
-If you really need cross-referencing for both PDF and other output
-formats, either downgrade to quarto 1.3, use a different package,
-or write code to emit appropriate references.
-\itemize{
+Quarto captions and table labels override values set with \code{\link[=caption]{caption()}} and
+\code{\link[=label]{label()}}. Huxtable warns if both mechanisms explicitly set the same
+property.
 \item I called \code{library(huxtable)} and now my \code{data.table} objects are getting
 printed!
 

--- a/man/huxtable-news.Rd
+++ b/man/huxtable-news.Rd
@@ -31,6 +31,9 @@ LaTeX command definitions are now registered as document dependencies
 and emitted once. Outside those documents, \code{to_html()},
 \code{print_html()}, \code{to_latex()} and \code{print_latex()} include them by
 default; use \code{dependencies = FALSE} to omit them.
+\item Bugfix: Quarto table captions and labels now override captions and
+labels set on a huxtable in HTML, PDF, Typst and Word output. Huxtable
+warns when both mechanisms explicitly set the same property.
 }
 }
 

--- a/man/label.Rd
+++ b/man/label.Rd
@@ -39,6 +39,9 @@ You can then refer to the table using \verb{@ref(label)}. \code{label} needs to 
 with \code{"tab:"}; if it doesn't, the \code{"tab:"} prefix will be added
 automatically. To turn off this behaviour, set
 \code{options(huxtable.bookdown = FALSE)}.
+
+Quarto table labels override labels set by this mechanism. A warning is
+issued if both are set.
 }
 \examples{
 set_label(jams, "tab:mytable")

--- a/tests/testthat/.gitignore
+++ b/tests/testthat/.gitignore
@@ -1,2 +1,3 @@
 /.quarto/
 /output_files/
+**/*.quarto_ipynb

--- a/tests/testthat/quarto-caption-precedence.qmd
+++ b/tests/testthat/quarto-caption-precedence.qmd
@@ -1,0 +1,35 @@
+---
+title: "Quarto caption precedence"
+format:
+  html: default
+  pdf:
+    keep-tex: true
+  typst:
+    keep-typ: true
+  docx: default
+execute:
+  echo: false
+  warning: false
+---
+
+See @tbl-quarto and @tbl-long.
+
+```{r}
+#| label: tbl-quarto
+#| tbl-cap: "Caption from Quarto"
+
+library(huxtable)
+hux(a = "Ordinary", add_colnames = FALSE) |>
+  set_caption("Caption from Huxtable") |>
+  set_label("tbl-huxtable")
+```
+
+```{r}
+#| label: tbl-long
+#| tbl-cap: "Breakable caption from Quarto"
+
+hux(a = 1:2, add_colnames = FALSE) |>
+  set_caption("Breakable caption from Huxtable") |>
+  set_label("tbl-huxtable-long") |>
+  set_breakable(TRUE)
+```

--- a/tests/testthat/test-captions.R
+++ b/tests/testthat/test-captions.R
@@ -61,6 +61,93 @@ test_that("Unnamed chunks and disabled autolabeling do not create labels", {
 })
 
 
+test_that("Bugfix: Quarto captions and labels override huxtable values", {
+  old_current <- knitr::opts_current$get()
+  old_knit <- knitr::opts_knit$get()
+  old_options <- options(huxtable.autolabel = TRUE, huxtable.bookdown = FALSE)
+  on.exit({
+    knitr::opts_current$restore(old_current)
+    knitr::opts_knit$restore(old_knit)
+    options(old_options)
+  })
+  knitr::opts_knit$set(quarto.version = "1.7.0")
+  knitr::opts_current$set(
+    label = "tbl-quarto",
+    `tbl-cap` = "Quarto caption"
+  )
+
+  ht <- set_label(set_caption(hux(a = 1), "Huxtable caption"), "tab:huxtable")
+  expect_warning(
+    caption_data <- resolve_caption(ht, "html"),
+    "caption and label"
+  )
+  expect_true(is.na(caption_data$text))
+  expect_true(is.na(caption_data$label))
+  expect_true(caption_data$quarto_caption)
+  expect_true(caption_data$quarto_label)
+
+  expect_no_warning(caption_data <- resolve_caption(hux(a = 1), "html"))
+  expect_true(is.na(caption_data$text))
+  expect_true(is.na(caption_data$label))
+
+  latex <- to_latex(hux(a = 1))
+  expect_false(grepl("\\QuartoMarkdownBase64", latex, fixed = TRUE))
+})
+
+
+test_that("Quarto caption and label ownership is resolved independently", {
+  old_current <- knitr::opts_current$get()
+  old_knit <- knitr::opts_knit$get()
+  old_options <- options(huxtable.autolabel = TRUE, huxtable.bookdown = FALSE)
+  on.exit({
+    knitr::opts_current$restore(old_current)
+    knitr::opts_knit$restore(old_knit)
+    options(old_options)
+  })
+  knitr::opts_knit$set(quarto.version = "1.7.0")
+
+  knitr::opts_current$set(
+    label = "unnamed-chunk-1",
+    `tbl-cap` = "Quarto caption"
+  )
+  expect_warning(
+    caption_data <- resolve_caption(
+      set_label(set_caption(hux(a = 1), "Huxtable caption"), "tab:huxtable"),
+      "html"
+    ),
+    "caption"
+  )
+  expect_true(is.na(caption_data$text))
+  expect_equal(caption_data$label, "tab:huxtable")
+  expect_true(caption_data$quarto_caption)
+  expect_false(caption_data$quarto_label)
+
+  knitr::opts_current$restore(old_current)
+  knitr::opts_current$set(label = "tbl-quarto")
+  caption_data <- resolve_caption(set_caption(hux(a = 1), "Huxtable caption"), "html")
+  expect_equal(caption_data$text, "Huxtable caption")
+  expect_true(is.na(caption_data$label))
+  expect_false(caption_data$quarto_caption)
+  expect_true(caption_data$quarto_label)
+
+  knitr::opts_current$restore(old_current)
+  knitr::opts_current$set(label = "analysis")
+  caption_data <- resolve_caption(set_label(hux(a = 1), "tab:huxtable"), "html")
+  expect_equal(caption_data$label, "tab:huxtable")
+  expect_false(caption_data$quarto_label)
+
+  knitr::opts_current$restore(old_current)
+  knitr::opts_current$set(
+    label = "tbl-subtables",
+    `tbl-subcap` = c("First", "Second")
+  )
+  caption_data <- resolve_caption(hux(a = 1), "html")
+  expect_true(caption_data$quarto_caption)
+  expect_true(caption_data$quarto_label)
+  expect_true(is.na(caption_data$label))
+})
+
+
 test_that("Bookdown captions include labels in the expected syntax", {
   old_options <- options(huxtable.bookdown = TRUE)
   on.exit(options(old_options))

--- a/tests/testthat/test-captions.R
+++ b/tests/testthat/test-captions.R
@@ -89,7 +89,7 @@ test_that("Bugfix: Quarto captions and labels override huxtable values", {
   expect_true(is.na(caption_data$label))
 
   latex <- to_latex(hux(a = 1))
-  expect_false(grepl("\\QuartoMarkdownBase64", latex, fixed = TRUE))
+  expect_no_match(latex, "\\QuartoMarkdownBase64", fixed = TRUE)
 })
 
 

--- a/tests/testthat/test-captions.R
+++ b/tests/testthat/test-captions.R
@@ -83,8 +83,6 @@ test_that("Bugfix: Quarto captions and labels override huxtable values", {
   )
   expect_true(is.na(caption_data$text))
   expect_true(is.na(caption_data$label))
-  expect_true(caption_data$quarto_caption)
-  expect_true(caption_data$quarto_label)
 
   expect_no_warning(caption_data <- resolve_caption(hux(a = 1), "html"))
   expect_true(is.na(caption_data$text))
@@ -119,22 +117,17 @@ test_that("Quarto caption and label ownership is resolved independently", {
   )
   expect_true(is.na(caption_data$text))
   expect_equal(caption_data$label, "tab:huxtable")
-  expect_true(caption_data$quarto_caption)
-  expect_false(caption_data$quarto_label)
 
   knitr::opts_current$restore(old_current)
   knitr::opts_current$set(label = "tbl-quarto")
   caption_data <- resolve_caption(set_caption(hux(a = 1), "Huxtable caption"), "html")
   expect_equal(caption_data$text, "Huxtable caption")
   expect_true(is.na(caption_data$label))
-  expect_false(caption_data$quarto_caption)
-  expect_true(caption_data$quarto_label)
 
   knitr::opts_current$restore(old_current)
   knitr::opts_current$set(label = "analysis")
   caption_data <- resolve_caption(set_label(hux(a = 1), "tab:huxtable"), "html")
   expect_equal(caption_data$label, "tab:huxtable")
-  expect_false(caption_data$quarto_label)
 
   knitr::opts_current$restore(old_current)
   knitr::opts_current$set(
@@ -142,8 +135,7 @@ test_that("Quarto caption and label ownership is resolved independently", {
     `tbl-subcap` = c("First", "Second")
   )
   caption_data <- resolve_caption(hux(a = 1), "html")
-  expect_true(caption_data$quarto_caption)
-  expect_true(caption_data$quarto_label)
+  expect_true(is.na(caption_data$text))
   expect_true(is.na(caption_data$label))
 })
 

--- a/tests/testthat/test-flextable.R
+++ b/tests/testthat/test-flextable.R
@@ -104,6 +104,26 @@ test_that("flextable maps breakable to Word pagination", {
 })
 
 
+test_that("Bugfix: Quarto captions override huxtable captions in Word", {
+  skip_if_not_installed("flextable")
+  skip_if_not_installed("knitr")
+  old_current <- knitr::opts_current$get()
+  old_knit <- knitr::opts_knit$get()
+  on.exit({
+    knitr::opts_current$restore(old_current)
+    knitr::opts_knit$restore(old_knit)
+  })
+  knitr::opts_knit$set(quarto.version = "1.7.0")
+  knitr::opts_current$set(label = "tbl-quarto", `tbl-cap` = "Quarto caption")
+
+  expect_warning(
+    ft <- as_flextable(set_caption(hux(a = 1), "Huxtable caption")),
+    "caption"
+  )
+  expect_null(ft$caption$value)
+})
+
+
 test_that("0-row/0-column huxtables work", {
   h_nrow0 <- hux(a = character(0), b = character(0), add_colnames = FALSE)
   h_ncol0 <- hux(a = 1:2)[, FALSE]

--- a/tests/testthat/test-yy-end-to-end.R
+++ b/tests/testthat/test-yy-end-to-end.R
@@ -172,13 +172,30 @@ test_that("Word files", {
 })
 
 
+test_quarto_render <- function(...) {
+  old_r_libs <- Sys.getenv("R_LIBS", unset = NA_character_)
+  on.exit({
+    if (is.na(old_r_libs)) {
+      Sys.unsetenv("R_LIBS")
+    } else {
+      Sys.setenv(R_LIBS = old_r_libs)
+    }
+  })
+  Sys.setenv(R_LIBS = paste(.libPaths(), collapse = .Platform$path.sep))
+  quarto::quarto_render(...)
+}
+
+
 test_that("quarto files", {
   skip_if_not_installed("quarto")
   qp <- quarto::quarto_path()
   skip_if_not(is.character(qp))
 
   on.exit({
-    for (f in c("quarto-test-out.pdf", "quarto-test-out.html")) {
+    for (f in c(
+      "quarto-test-out.pdf", "quarto-test-out.html",
+      "quarto-test-tex-labels-out.pdf"
+    )) {
       if (file.exists(f)) try(file.remove(f), silent = TRUE)
     }
     if (file.exists("quarto-test_files")) {
@@ -186,44 +203,124 @@ test_that("quarto files", {
     }
   })
 
-  if (quarto::quarto_version() < "1.4") {
-    expect_silent(
-      quarto::quarto_render("quarto-test.qmd",
-        output_format = "pdf",
-        output_file = "quarto-test-out.pdf",
-        execute_dir = "temp-artefacts",
-        debug = FALSE, quiet = TRUE
-      )
+  expect_silent(
+    test_quarto_render("quarto-test.qmd",
+      output_format = "pdf",
+      output_file = "quarto-test-out.pdf",
+      execute_dir = "temp-artefacts",
+      debug = FALSE, quiet = TRUE
     )
-  } else {
-    # for some reason (probably due to use of processx::) I can't
-    # capture the specific huxtable error from resolve_caption() here
-    expect_error(
-      quarto::quarto_render("quarto-test.qmd",
-        output_format = "pdf",
-        output_file = "quarto-test-out.pdf",
-        execute_dir = "temp-artefacts",
-        debug = FALSE, quiet = TRUE
-      )
+  )
+  expect_silent(
+    test_quarto_render("quarto-test-tex-labels.qmd",
+      output_format = "pdf",
+      output_file = "quarto-test-tex-labels-out.pdf",
+      execute_dir = "temp-artefacts",
+      debug = FALSE, quiet = TRUE
     )
-    expect_silent(
-      quarto::quarto_render("quarto-test-tex-labels.qmd",
-        output_format = "pdf",
-        output_file = "quarto-test-tex-labels-out.pdf",
-        execute_dir = "temp-artefacts",
-        debug = FALSE, quiet = TRUE
-      )
-    )
-  }
+  )
 
   expect_silent(
-    quarto::quarto_render("quarto-test.qmd",
+    test_quarto_render("quarto-test.qmd",
       output_format = "html",
       output_file = "quarto-test-out.html",
       execute_dir = "temp-artefacts",
       debug = FALSE, quiet = TRUE
     )
   )
+})
+
+
+test_that("Quarto captions and labels override huxtable output", {
+  skip_if_not_installed("quarto")
+  skip_if_not(is.character(quarto::quarto_path()))
+
+  outputs <- c(
+    "quarto-caption-precedence.html",
+    "quarto-caption-precedence.pdf",
+    "quarto-caption-precedence.tex",
+    "quarto-caption-precedence.typ",
+    "quarto-caption-precedence.docx"
+  )
+  on.exit({
+    for (f in outputs) if (file.exists(f)) try(file.remove(f), silent = TRUE)
+    if (file.exists("quarto-caption-precedence_files")) {
+      try(unlink("quarto-caption-precedence_files", recursive = TRUE), silent = TRUE)
+    }
+  })
+
+  expect_silent(
+    test_quarto_render("quarto-caption-precedence.qmd",
+      output_format = "html",
+      output_file = "quarto-caption-precedence.html",
+      execute_dir = "temp-artefacts",
+      debug = FALSE, quiet = TRUE
+    )
+  )
+  html <- paste(readLines("quarto-caption-precedence.html", warn = FALSE), collapse = "\n")
+  expect_match(html, "Caption from Quarto", fixed = TRUE)
+  expect_match(html, 'id="tbl-quarto"', fixed = TRUE)
+  expect_match(html, 'href="#tbl-quarto"', fixed = TRUE)
+  expect_false(grepl("Caption from Huxtable", html, fixed = TRUE))
+  expect_false(grepl("tbl-huxtable", html, fixed = TRUE))
+
+  expect_silent(
+    test_quarto_render("quarto-caption-precedence.qmd",
+      output_format = "pdf",
+      output_file = "quarto-caption-precedence.pdf",
+      execute_dir = "temp-artefacts",
+      debug = FALSE, quiet = TRUE
+    )
+  )
+  tex <- paste(readLines("quarto-caption-precedence.tex", warn = FALSE), collapse = "\n")
+  expect_match(tex, "Caption from Quarto", fixed = TRUE)
+  expect_match(tex, "\\label{tbl-quarto}", fixed = TRUE)
+  expect_match(tex, "\\begin{longtable}", fixed = TRUE)
+  expect_match(tex, "Breakable caption from Quarto", fixed = TRUE)
+  expect_match(tex, "\\label{tbl-long}", fixed = TRUE)
+  expect_false(grepl("caption from Huxtable", tex, ignore.case = TRUE))
+  expect_false(grepl("tbl-huxtable", tex, fixed = TRUE))
+
+  expect_silent(
+    test_quarto_render("quarto-caption-precedence.qmd",
+      output_format = "typst",
+      output_file = "quarto-caption-precedence.pdf",
+      execute_dir = "temp-artefacts",
+      debug = FALSE, quiet = TRUE
+    )
+  )
+  typ <- paste(readLines("quarto-caption-precedence.typ", warn = FALSE), collapse = "\n")
+  expect_match(typ, "Caption from Quarto", fixed = TRUE)
+  expect_match(typ, "<tbl-quarto>", fixed = TRUE)
+  expect_match(typ, "#ref(<tbl-quarto>", fixed = TRUE)
+  expect_false(grepl("Caption from Huxtable", typ, fixed = TRUE))
+  expect_false(grepl("tbl-huxtable", typ, fixed = TRUE))
+
+  skip_if_not_installed("flextable")
+  expect_silent(
+    test_quarto_render("quarto-caption-precedence.qmd",
+      output_format = "docx",
+      output_file = "quarto-caption-precedence.docx",
+      execute_dir = "temp-artefacts",
+      debug = FALSE, quiet = TRUE
+    )
+  )
+  docx_dir <- tempfile("quarto-docx-")
+  dir.create(docx_dir)
+  on.exit(unlink(docx_dir, recursive = TRUE), add = TRUE)
+  utils::unzip(
+    "quarto-caption-precedence.docx",
+    files = "word/document.xml",
+    exdir = docx_dir
+  )
+  word_xml <- paste(
+    readLines(file.path(docx_dir, "word/document.xml"), warn = FALSE),
+    collapse = "\n"
+  )
+  expect_match(word_xml, "Caption from Quarto", fixed = TRUE)
+  expect_match(word_xml, "tbl-quarto", fixed = TRUE)
+  expect_false(grepl("Caption from Huxtable", word_xml, fixed = TRUE))
+  expect_false(grepl("tbl-huxtable", word_xml, fixed = TRUE))
 })
 
 

--- a/tests/testthat/test-yy-end-to-end.R
+++ b/tests/testthat/test-yy-end-to-end.R
@@ -261,8 +261,8 @@ test_that("Quarto captions and labels override huxtable output", {
   expect_match(html, "Caption from Quarto", fixed = TRUE)
   expect_match(html, 'id="tbl-quarto"', fixed = TRUE)
   expect_match(html, 'href="#tbl-quarto"', fixed = TRUE)
-  expect_false(grepl("Caption from Huxtable", html, fixed = TRUE))
-  expect_false(grepl("tbl-huxtable", html, fixed = TRUE))
+  expect_no_match(html, "Caption from Huxtable", fixed = TRUE)
+  expect_no_match(html, "tbl-huxtable", fixed = TRUE)
 
   expect_silent(
     test_quarto_render("quarto-caption-precedence.qmd",
@@ -278,8 +278,8 @@ test_that("Quarto captions and labels override huxtable output", {
   expect_match(tex, "\\begin{longtable}", fixed = TRUE)
   expect_match(tex, "Breakable caption from Quarto", fixed = TRUE)
   expect_match(tex, "\\label{tbl-long}", fixed = TRUE)
-  expect_false(grepl("caption from Huxtable", tex, ignore.case = TRUE))
-  expect_false(grepl("tbl-huxtable", tex, fixed = TRUE))
+  expect_no_match(tex, "caption from Huxtable", ignore.case = TRUE)
+  expect_no_match(tex, "tbl-huxtable", fixed = TRUE)
 
   expect_silent(
     test_quarto_render("quarto-caption-precedence.qmd",
@@ -293,8 +293,8 @@ test_that("Quarto captions and labels override huxtable output", {
   expect_match(typ, "Caption from Quarto", fixed = TRUE)
   expect_match(typ, "<tbl-quarto>", fixed = TRUE)
   expect_match(typ, "#ref(<tbl-quarto>", fixed = TRUE)
-  expect_false(grepl("Caption from Huxtable", typ, fixed = TRUE))
-  expect_false(grepl("tbl-huxtable", typ, fixed = TRUE))
+  expect_no_match(typ, "Caption from Huxtable", fixed = TRUE)
+  expect_no_match(typ, "tbl-huxtable", fixed = TRUE)
 
   skip_if_not_installed("flextable")
   expect_silent(
@@ -319,8 +319,8 @@ test_that("Quarto captions and labels override huxtable output", {
   )
   expect_match(word_xml, "Caption from Quarto", fixed = TRUE)
   expect_match(word_xml, "tbl-quarto", fixed = TRUE)
-  expect_false(grepl("Caption from Huxtable", word_xml, fixed = TRUE))
-  expect_false(grepl("tbl-huxtable", word_xml, fixed = TRUE))
+  expect_no_match(word_xml, "Caption from Huxtable", fixed = TRUE)
+  expect_no_match(word_xml, "tbl-huxtable", fixed = TRUE)
 })
 
 


### PR DESCRIPTION
## Summary
- centralize Quarto caption and table-label ownership in resolve_caption()
- let Quarto values override explicit huxtable values with one conflict warning per table
- apply the resolved caption to HTML, LaTeX, Markdown, Typst, Word and PowerPoint paths
- remove the obsolete Quarto 1.4 PDF-label error and empty LaTeX caption payload
- update the FAQ, property documentation, NEWS and architecture notes

## Tests
- add unit coverage for Quarto-only, huxtable-only, mixed, conflicting, automatic and unnamed label cases
- add semantic end-to-end assertions for Quarto HTML, ordinary and breakable PDF, Typst and Word output
- verified the end-to-end file locally: 60 passed
- verified the broader non-fuzz/non-snapshot suite: 1,502 passed; two order-dependent pkgload system.file() failures passed when rerun alone